### PR TITLE
Remove CommonAPI dependency

### DIFF
--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -1,4 +1,5 @@
-﻿using NebulaAPI;
+﻿using BepInEx.Configuration;
+using NebulaAPI;
 using NebulaModel.Attributes;
 using NebulaModel.DataStructures;
 using NebulaModel.Utils;
@@ -88,6 +89,10 @@ namespace NebulaModel
                 UpdateInputFieldContentType(ref hostIpInput);
             }
         }
+
+        [DisplayName("Chat Hotkey"), Category("Chat")]
+        [Description("Keyboard shortcut to toggle the chat window")]
+        public KeyboardShortcut ChatHotkey { get; set; } = new KeyboardShortcut(KeyCode.BackQuote, KeyCode.LeftAlt);
 
         [DisplayName("Auto Open Chat"), Category("Chat")]
         [Description("Auto open chat window when receiving message from other players")]

--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -61,6 +61,10 @@ namespace NebulaModel
         [Description("Configure which type of IP should be used by Discord RPC")]
         public IPUtils.IPConfiguration IPConfiguration { get; set; }
 
+        [DisplayName("Cleanup inactive sessions"), Category("Network")]
+        [Description("If disabled the underlying networking library will not cleanup inactive connections. This might solve issues with clients randomly disconnecting and hosts having a 'System.ObjectDisposedException'.")]
+        public bool CleanupInactiveSessions { get; set; } = false;
+
         [DisplayName("Show Lobby Hints")]
         public bool ShowLobbyHints { get; set; } = true;
 
@@ -111,11 +115,12 @@ namespace NebulaModel
         public ChatSize DefaultChatSize { get; set; } = ChatSize.Medium;
 
         [DisplayName("Notification duration"), Category("Chat")]
+        [Description("How long should the active message stay on the screen in seconds")]
         public int NotificationDuration { get; set; } = 15;
 
-        [DisplayName("Cleanup inactive sessions"), Category("Network")]
-        [Description("If disabled the underlying networking library will not cleanup inactive connections. This might solve issues with clients randomly disconnecting and hosts having a 'System.ObjectDisposedException'.")]
-        public bool CleanupInactiveSessions { get; set; } = true;
+        [DisplayName("Chat Window Opacity"), Category("Chat")]
+        [UIRange(0f, 1.0f, true)]
+        public float ChatWindowOpacity { get; set; } = 0.8f;
 
         // Detail function group buttons
         public bool PowerGridEnabled { get; set; } = false;

--- a/NebulaPatcher/MonoBehaviours/NebulaBootstrapper.cs
+++ b/NebulaPatcher/MonoBehaviours/NebulaBootstrapper.cs
@@ -1,5 +1,4 @@
-﻿using CommonAPI.Systems;
-using NebulaWorld;
+﻿using NebulaWorld;
 using UnityEngine;
 
 namespace NebulaPatcher.MonoBehaviours

--- a/NebulaPatcher/NebulaPlugin.cs
+++ b/NebulaPatcher/NebulaPlugin.cs
@@ -1,6 +1,4 @@
 ﻿using BepInEx;
-using CommonAPI;
-using CommonAPI.Systems;
 using HarmonyLib;
 using NebulaAPI;
 using NebulaModel.Logger;
@@ -20,8 +18,7 @@ using UnityEngine;
 namespace NebulaPatcher
 {
     [BepInPlugin(PluginInfo.PLUGIN_ID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-    [BepInDependency(CommonAPIPlugin.GUID)]
-    [CommonAPISubmoduleDependency(nameof(ProtoRegistry), nameof(CustomKeyBindSystem))]
+    [BepInDependency("dsp.common - api.CommonAPI", BepInDependency.DependencyFlags.SoftDependency)]
     public class NebulaPlugin : BaseUnityPlugin, IMultiplayerMod
     {
         static int command_ups = 0;
@@ -176,7 +173,6 @@ namespace NebulaPatcher
         {
             InitPatches();
             AddNebulaBootstrapper();
-            RegisterKeyBinds();
             DiscordManager.Setup(ActivityManager_OnActivityJoin);
         }
 
@@ -283,19 +279,6 @@ namespace NebulaPatcher
             {
                 DiscordManager.Update();
             }
-        }
-
-        private static void RegisterKeyBinds()
-        {
-            CustomKeyBindSystem.RegisterKeyBind<PressKeyBind>(new BuiltinKey
-            {
-                id = 212,
-                key = new CombineKey((int)KeyCode.BackQuote, CombineKey.ALT_COMB, ECombineKeyAction.OnceClick, false),
-                conflictGroup = 2052,
-                name = "NebulaChatWindow",
-                canOverride = true
-            });
-            ProtoRegistry.RegisterString("KEYNebulaChatWindow", "Show or Hide Chat Window");
         }
 
         private static void InitPatches()

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
@@ -1,6 +1,4 @@
-﻿using CommonAPI;
-using CommonAPI.Systems;
-using NebulaModel;
+﻿using NebulaModel;
 using NebulaModel.DataStructures;
 using NebulaModel.Logger;
 using NebulaModel.Packets.Players;
@@ -35,8 +33,6 @@ namespace NebulaWorld.MonoBehaviours.Local
 
                 trans.sizeDelta = defaultSize;
                 trans.anchoredPosition = defaultPos;
-
-                chatGo.GetComponent<UIWindowResize>().minSize = ChatUtils.GetDefaultSize(ChatSize.Small);
             }
 
             chatWindow = chatGo.transform.GetComponentInChildren<ChatWindow>();
@@ -64,7 +60,7 @@ namespace NebulaWorld.MonoBehaviours.Local
 
         void Update()
         {
-            if (CustomKeyBindSystem.GetKeyBind("NebulaChatWindow").keyValue)
+            if (Config.Options.ChatHotkey.IsDown())
             {
                 chatWindow.Toggle();
             }

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatManager.cs
@@ -5,12 +5,14 @@ using NebulaModel.Packets.Players;
 using NebulaModel.Utils;
 using System;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace NebulaWorld.MonoBehaviours.Local
 {
     public class ChatManager : MonoBehaviour
     {
         private ChatWindow chatWindow;
+        private Image backgroundImage;
         public static ChatManager Instance;
 
         private void Awake()
@@ -33,6 +35,12 @@ namespace NebulaWorld.MonoBehaviours.Local
 
                 trans.sizeDelta = defaultSize;
                 trans.anchoredPosition = defaultPos;
+
+                // TODO: Fix ChatV2.prefab to get rid of warnings
+                GameObject backgroundGo = chatGo.transform.Find("Main/background").gameObject;
+                DestroyImmediate(backgroundGo.GetComponent<TranslucentImage>());
+                backgroundImage = backgroundGo.AddComponent<Image>();
+                backgroundImage.color = new Color(0f, 0f, 0f, options.ChatWindowOpacity);
             }
 
             chatWindow = chatGo.transform.GetComponentInChildren<ChatWindow>();
@@ -56,6 +64,7 @@ namespace NebulaWorld.MonoBehaviours.Local
             RectTransform trans = (RectTransform)Instance.chatWindow.transform;
             trans.anchoredPosition = defaultPos;
             trans.sizeDelta = defaultSize;
+            Instance.backgroundImage.color = new Color(0f, 0f, 0f, options.ChatWindowOpacity);
         }
 
         void Update()


### PR DESCRIPTION
- Replace CommonAPI functions so no need to install CommonAPI in the future.
- Add `CreateHotkeyControl` to support [KeyboardShortcut](https://docs.bepinex.dev/api/BepInEx.Configuration.KeyboardShortcut.html) type in MultiplayerOptions. 
The available Keycode string can be found in [Unity Doc](https://docs.unity3d.com/2018.4/Documentation/ScriptReference/KeyCode.html). The input text will turn red if it is invalid.  
- Add ChatHotkey, ChatWindowOpacity config options

![chat config](https://github.com/NebulaModTeam/nebula/assets/50672801/67a6c357-7f6f-4944-9d53-28f1ee4ea155)
