### PR TITLE
Add support for syncing dark fog settings in lobby and combat setting…

### DIFF
--- a/NebulaModel/Packets/Session/LobbyUpdateCombatValues.cs
+++ b/NebulaModel/Packets/Session/LobbyUpdateCombatValues.cs
@@ -1,0 +1,30 @@
+﻿namespace NebulaModel.Packets.Session
+{
+    public class LobbyUpdateCombatValues
+    {
+        public LobbyUpdateCombatValues() { }
+
+        public LobbyUpdateCombatValues(CombatSettings combatSettings)
+        {
+            CombatAggressiveness = combatSettings.aggressiveness;
+            CombatInitialLevel = combatSettings.initialLevel;
+            CombatInitialGrowth = combatSettings.initialGrowth;
+            CombatInitialColonize = combatSettings.initialColonize;
+            CombatMaxDensity = combatSettings.maxDensity;
+            CombatGrowthSpeedFactor = combatSettings.growthSpeedFactor;
+            CombatPowerThreatFactor = combatSettings.powerThreatFactor;
+            CombatBattleThreatFactor = combatSettings.battleThreatFactor;
+            CombatBattleExpFactor = combatSettings.battleExpFactor;
+        }
+
+        public float CombatAggressiveness { get; set; }
+        public float CombatInitialLevel { get; set; }
+        public float CombatInitialGrowth { get; set; }
+        public float CombatInitialColonize { get; set; }
+        public float CombatMaxDensity { get; set; }
+        public float CombatGrowthSpeedFactor { get; set; }
+        public float CombatPowerThreatFactor { get; set; }
+        public float CombatBattleThreatFactor { get; set; }
+        public float CombatBattleExpFactor { get; set; }
+    }
+}

--- a/NebulaModel/Packets/Session/LobbyUpdateValues.cs
+++ b/NebulaModel/Packets/Session/LobbyUpdateValues.cs
@@ -4,13 +4,23 @@ public class LobbyUpdateValues
 {
     public LobbyUpdateValues() { }
 
-    public LobbyUpdateValues(int galaxyAlgo, int galaxySeed, int starCount, float resourceMultiplier, bool isSandboxMode)
+    public LobbyUpdateValues(int galaxyAlgo, int galaxySeed, int starCount, float resourceMultiplier, bool isSandboxMode, bool isPeaceMode, CombatSettings combatSettings)
     {
         GalaxyAlgo = galaxyAlgo;
         GalaxySeed = galaxySeed;
         StarCount = starCount;
         ResourceMultiplier = resourceMultiplier;
         IsSandboxMode = isSandboxMode;
+        IsPeaceMode = isPeaceMode;
+        CombatAggressiveness = combatSettings.aggressiveness;
+        CombatInitialLevel = combatSettings.initialLevel;
+        CombatInitialGrowth = combatSettings.initialGrowth;
+        CombatInitialColonize = combatSettings.initialColonize;
+        CombatMaxDensity = combatSettings.maxDensity;
+        CombatGrowthSpeedFactor = combatSettings.growthSpeedFactor;
+        CombatPowerThreatFactor = combatSettings.powerThreatFactor;
+        CombatBattleThreatFactor = combatSettings.battleThreatFactor;
+        CombatBattleExpFactor = combatSettings.battleExpFactor;
     }
 
     public int GalaxyAlgo { get; set; }
@@ -18,4 +28,14 @@ public class LobbyUpdateValues
     public int StarCount { get; set; }
     public float ResourceMultiplier { get; set; }
     public bool IsSandboxMode { get; set; }
+    public bool IsPeaceMode { get; set; }
+    public float CombatAggressiveness { get; set; }
+    public float CombatInitialLevel { get; set; }
+    public float CombatInitialGrowth { get; set; }
+    public float CombatInitialColonize { get; set; }
+    public float CombatMaxDensity { get; set; }
+    public float CombatGrowthSpeedFactor { get; set; }
+    public float CombatPowerThreatFactor { get; set; }
+    public float CombatBattleThreatFactor { get; set; }
+    public float CombatBattleExpFactor { get; set; }
 }

--- a/NebulaNetwork/PacketProcessors/Session/LobbyUpdateCombatValuesProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyUpdateCombatValuesProcessor.cs
@@ -1,0 +1,40 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Session;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Session
+{
+    [RegisterPacketProcessor]
+    internal class LobbyUpdateCombatValuesProcessor:PacketProcessor<LobbyUpdateCombatValues>
+    {
+        protected override void ProcessPacket(LobbyUpdateCombatValues packet, NebulaConnection conn)
+        {
+            if (IsHost)
+            {
+                return;
+            }
+
+            var gameDesc = UIRoot.instance.galaxySelect.gameDesc;
+            if (!gameDesc.isPeaceMode)
+            {
+                gameDesc.combatSettings.aggressiveness = packet.CombatAggressiveness;
+                gameDesc.combatSettings.initialLevel = packet.CombatInitialLevel;
+                gameDesc.combatSettings.initialGrowth = packet.CombatInitialGrowth;
+                gameDesc.combatSettings.initialColonize = packet.CombatInitialColonize;
+                gameDesc.combatSettings.maxDensity = packet.CombatMaxDensity;
+                gameDesc.combatSettings.growthSpeedFactor = packet.CombatGrowthSpeedFactor;
+                gameDesc.combatSettings.powerThreatFactor = packet.CombatPowerThreatFactor;
+                gameDesc.combatSettings.battleThreatFactor = packet.CombatBattleThreatFactor;
+                gameDesc.combatSettings.battleExpFactor = packet.CombatBattleExpFactor;
+            }
+
+            UIRoot.instance.galaxySelect.gameDesc = gameDesc;
+            UIRoot.instance.galaxySelect.SetStarmapGalaxy();
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Session/LobbyUpdateValuesProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyUpdateValuesProcessor.cs
@@ -22,6 +22,19 @@ internal class LobbyUpdateValuesProcessor : PacketProcessor<LobbyUpdateValues>
         var gameDesc = new GameDesc();
         gameDesc.SetForNewGame(packet.GalaxyAlgo, packet.GalaxySeed, packet.StarCount, 1, packet.ResourceMultiplier);
         gameDesc.isSandboxMode = packet.IsSandboxMode;
+        gameDesc.isPeaceMode = packet.IsPeaceMode;
+        if (!packet.IsPeaceMode)
+        {
+            gameDesc.combatSettings.aggressiveness = packet.CombatAggressiveness;
+            gameDesc.combatSettings.initialLevel = packet.CombatInitialLevel;
+            gameDesc.combatSettings.initialGrowth = packet.CombatInitialGrowth;
+            gameDesc.combatSettings.initialColonize = packet.CombatInitialColonize;
+            gameDesc.combatSettings.maxDensity = packet.CombatMaxDensity;
+            gameDesc.combatSettings.growthSpeedFactor = packet.CombatGrowthSpeedFactor;
+            gameDesc.combatSettings.powerThreatFactor = packet.CombatPowerThreatFactor;
+            gameDesc.combatSettings.battleThreatFactor = packet.CombatBattleThreatFactor;
+            gameDesc.combatSettings.battleExpFactor = packet.CombatBattleExpFactor;
+        }
 
         UIRoot.instance.galaxySelect.gameDesc = gameDesc;
         UIRoot.instance.galaxySelect.SetStarmapGalaxy();

--- a/NebulaPatcher/Patches/Dynamic/UICombatSettingsDF_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UICombatSettingsDF_Patch.cs
@@ -1,0 +1,46 @@
+﻿#region
+
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using NebulaModel;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Session;
+using NebulaPatcher.Patches.Transpilers;
+using NebulaWorld;
+using UnityEngine;
+using UnityEngine.UI;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Dynamic
+{
+    [HarmonyPatch(typeof(UICombatSettingsDF))]
+    internal class UICombatSettingsDF_Patch
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(UICombatSettingsDF.ApplySettings))]
+        public static void ApplySettings_Postfix(UICombatSettingsDF __instance)
+        {
+            if (!Multiplayer.IsInMultiplayerMenu || !Multiplayer.Session.LocalPlayer.IsHost)
+            {
+                return;
+            }
+            // syncing players are those who have not loaded into the game yet, so they might still be in the lobby. they need to check if this packet is relevant for them in the corresponding handler.
+            // just remembered others cant be in game anyways when host ist still in lobby >.>
+            using (Multiplayer.Session.Network.PlayerManager.GetSyncingPlayers(out var syncingPlayers))
+            {
+                foreach (var entry in syncingPlayers)
+                {
+                    entry.Key.SendPacket(new LobbyUpdateCombatValues(__instance.gameDesc.combatSettings));
+                }
+            }
+            using (Multiplayer.Session.Network.PlayerManager.GetPendingPlayers(out var pendingPlayers))
+            {
+                foreach (var entry in pendingPlayers)
+                {
+                    entry.Key.SendPacket(new LobbyUpdateCombatValues(__instance.gameDesc.combatSettings));
+                }
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
@@ -35,6 +35,7 @@ internal class UIGalaxySelect_Patch
             galaxySelectRect.Find("property-multiplier").gameObject.SetActive(false);
             galaxySelectRect.Find("seed-key").gameObject.SetActive(false);
             galaxySelectRect.Find("sandbox-mode").gameObject.SetActive(false);
+            galaxySelectRect.Find("DF-toggle").gameObject.SetActive(false);
         }
         if (!Multiplayer.IsActive)
         {
@@ -141,6 +142,7 @@ internal class UIGalaxySelect_Patch
         galaxySelectRect.Find("resource-multiplier").gameObject.SetActive(true);
         galaxySelectRect.Find("galaxy-seed").GetComponentInChildren<InputField>().enabled = true;
         galaxySelectRect.Find("random-button").gameObject.SetActive(true);
+        galaxySelectRect.Find("DF-toggle").gameObject.SetActive(true);
     }
 
     [HarmonyPrefix]
@@ -181,7 +183,7 @@ internal class UIGalaxySelect_Patch
             {
                 entry.Key.SendPacket(new LobbyUpdateValues(__instance.gameDesc.galaxyAlgo, __instance.gameDesc.galaxySeed,
                     __instance.gameDesc.starCount, __instance.gameDesc.resourceMultiplier,
-                    __instance.gameDesc.isSandboxMode));
+                    __instance.gameDesc.isSandboxMode, __instance.gameDesc.isPeaceMode, __instance.gameDesc.combatSettings));
             }
         }
         using (Multiplayer.Session.Network.PlayerManager.GetPendingPlayers(out var pendingPlayers))
@@ -190,7 +192,7 @@ internal class UIGalaxySelect_Patch
             {
                 entry.Key.SendPacket(new LobbyUpdateValues(__instance.gameDesc.galaxyAlgo, __instance.gameDesc.galaxySeed,
                     __instance.gameDesc.starCount, __instance.gameDesc.resourceMultiplier,
-                    __instance.gameDesc.isSandboxMode));
+                    __instance.gameDesc.isSandboxMode, __instance.gameDesc.isPeaceMode, __instance.gameDesc.combatSettings));
             }
         }
     }


### PR DESCRIPTION
Added support for syncing dark fog settings in lobby and combat settings.  This should sync up the combat settings when saving the combat settings and then update everything when updating the other settings.  I initially wanted to try to have the combat settings not needed to be sent every time, but with the reset done by the normal settings screen, the entire gameDesc object needs to be rebuilt, including the combat settings.

I have not been able to test this yet as the mod is not yet working without exceptions, so use it with some caution.