### PR TITLE
Fix WarningData error when placing blueprint & refactor BuildTool

### DIFF
--- a/NebulaAPI/GameState/IFactoryManager.cs
+++ b/NebulaAPI/GameState/IFactoryManager.cs
@@ -44,8 +44,4 @@ public interface IFactoryManager : IDisposable
     int GetNextPrebuildId(int planetId);
 
     int GetNextPrebuildId(PlanetFactory factory);
-
-    void OnNewSetInserterPickTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos);
-
-    void OnNewSetInserterInsertTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos);
 }

--- a/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
+++ b/NebulaModel/Packets/Factory/CreatePrebuildsRequest.cs
@@ -37,21 +37,29 @@ public class CreatePrebuildsRequest
     public string BuildToolType { get; set; }
     public int PrebuildId { get; set; }
 
-    public List<BuildPreview> GetBuildPreviews()
+    public bool TryGetBuildPreviews(out List<BuildPreview> buildPreviews)
     {
-        var result = new List<BuildPreview>();
+        buildPreviews = new();
 
-        using var reader = new BinaryUtils.Reader(BuildPreviewData);
-        var previewCount = reader.BinaryReader.ReadInt32();
-        for (var i = 0; i < previewCount; i++)
+        try
         {
-            result.Add(new BuildPreview());
+            using var reader = new BinaryUtils.Reader(BuildPreviewData);
+            var previewCount = reader.BinaryReader.ReadInt32();
+            for (var i = 0; i < previewCount; i++)
+            {
+                buildPreviews.Add(new BuildPreview());
+            }
+            for (var i = 0; i < previewCount; i++)
+            {
+                DeserializeBuildPreview(buildPreviews[i], buildPreviews, reader.BinaryReader);
+            }
+            return true;
         }
-        for (var i = 0; i < previewCount; i++)
+        catch (System.Exception e)
         {
-            DeserializeBuildPreview(result[i], result, reader.BinaryReader);
+            Logger.Log.WarnInform("DeserializeBuildPreview parse error\n" + e);
+            return false;
         }
-        return result;
     }
 
     public static void DeserializeBuildPreview(BuildPreview buildPreview, IReadOnlyList<BuildPreview> list, BinaryReader br)
@@ -88,69 +96,26 @@ public class CreatePrebuildsRequest
         buildPreview.recipeId = br.ReadInt32();
         buildPreview.filterId = br.ReadInt32();
         buildPreview.isConnNode = br.ReadBoolean();
-        buildPreview.desc = new PrefabDesc
-        {
-            //Import more data about the Prefab to properly validate the build condition on server-side
-            assemblerRecipeType = (ERecipeType)br.ReadInt32(),
-            cullingHeight = br.ReadSingle(),
-            gammaRayReceiver = br.ReadBoolean(),
-            inserterSTT = br.ReadInt32(),
-            isAccumulator = br.ReadBoolean(),
-            isAssembler = br.ReadBoolean(),
-            isBelt = br.ReadBoolean(),
-            isCollectStation = br.ReadBoolean(),
-            isDispenser = br.ReadBoolean(),
-            isEjector = br.ReadBoolean(),
-            isFractionator = br.ReadBoolean(),
-            isInserter = br.ReadBoolean(),
-            isLab = br.ReadBoolean(),
-            isPowerExchanger = br.ReadBoolean(),
-            isSplitter = br.ReadBoolean(),
-            isStation = br.ReadBoolean(),
-            isStellarStation = br.ReadBoolean(),
-            isStorage = br.ReadBoolean(),
-            isTank = br.ReadBoolean(),
-            isVeinCollector = br.ReadBoolean(),
-            minerType = (EMinerType)br.ReadInt32(),
-            modelIndex = br.ReadInt32(),
-            multiLevel = br.ReadBoolean(),
-            oilMiner = br.ReadBoolean(),
-            stationCollectSpeed = br.ReadInt32(),
-            veinMiner = br.ReadBoolean(),
-            windForcedPower = br.ReadBoolean(),
-            workEnergyPerTick = br.ReadInt64()
-        };
 
-        //Import information about the position of build (land / sea)
-        num = br.ReadInt32();
-        buildPreview.desc.landPoints = new Vector3[num];
-        for (var i = 0; i < num; i++)
+        var modelIndex = br.ReadInt32();
+        if (modelIndex >= 0 && modelIndex < LDB.models.modelArray.Length)
         {
-            buildPreview.desc.landPoints[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            var modelProto = LDB.models.modelArray[modelIndex];
+            if (modelProto != null)
+            {
+                buildPreview.desc = modelProto.prefabDesc;
+            }
         }
-        num = br.ReadInt32();
-        buildPreview.desc.waterPoints = new Vector3[num];
-        for (var i = 0; i < num; i++)
+        if (buildPreview.desc == null)
         {
-            buildPreview.desc.waterPoints[i] = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
+            throw new System.Exception("DeserializeBuildPreview: can't find modelIndx " + modelIndex);
         }
-
-        //Import information about the collider to check the collisions
-        buildPreview.desc.hasBuildCollider = br.ReadBoolean();
-        num = br.ReadInt32();
-        buildPreview.desc.buildColliders = new ColliderData[num];
-        for (var i = 0; i < num; i++)
+        var itemId = br.ReadInt32();
+        buildPreview.item = LDB.items.Select(itemId);
+        if (buildPreview.item == null)
         {
-            buildPreview.desc.buildColliders[i].pos = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-            buildPreview.desc.buildColliders[i].ext = new Vector3(br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-            buildPreview.desc.buildColliders[i].q =
-                new Quaternion(br.ReadSingle(), br.ReadSingle(), br.ReadSingle(), br.ReadSingle());
-            buildPreview.desc.buildColliders[i].radius = br.ReadSingle();
-            buildPreview.desc.buildColliders[i].idType = br.ReadInt32();
-            buildPreview.desc.buildColliders[i].link = br.ReadInt32();
+            throw new System.Exception("DeserializeBuildPreview: can't find itemId " + itemId);
         }
-
-        buildPreview.item = new ItemProto { ID = br.ReadInt32(), BuildMode = br.ReadInt32(), Grade = br.ReadInt32() };
 
         buildPreview.paramCount = br.ReadInt32();
         buildPreview.parameters = new int[buildPreview.paramCount];
@@ -195,77 +160,11 @@ public class CreatePrebuildsRequest
         bw.Write(buildPreview.filterId);
         bw.Write(buildPreview.isConnNode);
 
-        //Export more data about the Prefab to properly validate the build condition on server-side
-        bw.Write((int)buildPreview.desc.assemblerRecipeType);
-        bw.Write(buildPreview.desc.cullingHeight);
-        bw.Write(buildPreview.desc.gammaRayReceiver);
-        bw.Write(buildPreview.desc.inserterSTT);
-        bw.Write(buildPreview.desc.isAccumulator);
-        bw.Write(buildPreview.desc.isAssembler);
-        bw.Write(buildPreview.desc.isBelt);
-        bw.Write(buildPreview.desc.isCollectStation);
-        bw.Write(buildPreview.desc.isDispenser);
-        bw.Write(buildPreview.desc.isEjector);
-        bw.Write(buildPreview.desc.isFractionator);
-        bw.Write(buildPreview.desc.isInserter);
-        bw.Write(buildPreview.desc.isLab);
-        bw.Write(buildPreview.desc.isPowerExchanger);
-        bw.Write(buildPreview.desc.isSplitter);
-        bw.Write(buildPreview.desc.isStation);
-        bw.Write(buildPreview.desc.isStellarStation);
-        bw.Write(buildPreview.desc.isStorage);
-        bw.Write(buildPreview.desc.isTank);
-        bw.Write(buildPreview.desc.isVeinCollector);
-        bw.Write((int)buildPreview.desc.minerType);
+        //Export the index of PrefabDesc and fetch in LDB.models on the receiving end
         bw.Write(buildPreview.desc.modelIndex);
-        bw.Write(buildPreview.desc.multiLevel);
-        bw.Write(buildPreview.desc.oilMiner);
-        bw.Write(buildPreview.desc.stationCollectSpeed);
-        bw.Write(buildPreview.desc.veinMiner);
-        bw.Write(buildPreview.desc.windForcedPower);
-        bw.Write(buildPreview.desc.workEnergyPerTick);
-
-        //Export information about the position of build (land / sea)
-        num = buildPreview.desc.landPoints.Length;
-        bw.Write(num);
-        for (var i = 0; i < num; i++)
-        {
-            bw.Write(buildPreview.desc.landPoints[i].x);
-            bw.Write(buildPreview.desc.landPoints[i].y);
-            bw.Write(buildPreview.desc.landPoints[i].z);
-        }
-        num = buildPreview.desc.waterPoints.Length;
-        bw.Write(num);
-        for (var i = 0; i < num; i++)
-        {
-            bw.Write(buildPreview.desc.waterPoints[i].x);
-            bw.Write(buildPreview.desc.waterPoints[i].y);
-            bw.Write(buildPreview.desc.waterPoints[i].z);
-        }
-        //Export information about the collider to check the collisions
-        bw.Write(buildPreview.desc.hasBuildCollider);
-        num = buildPreview.desc.buildColliders.Length;
-        bw.Write(num);
-        for (var i = 0; i < num; i++)
-        {
-            bw.Write(buildPreview.desc.buildColliders[i].pos.x);
-            bw.Write(buildPreview.desc.buildColliders[i].pos.y);
-            bw.Write(buildPreview.desc.buildColliders[i].pos.z);
-            bw.Write(buildPreview.desc.buildColliders[i].ext.x);
-            bw.Write(buildPreview.desc.buildColliders[i].ext.y);
-            bw.Write(buildPreview.desc.buildColliders[i].ext.z);
-            bw.Write(buildPreview.desc.buildColliders[i].q.x);
-            bw.Write(buildPreview.desc.buildColliders[i].q.y);
-            bw.Write(buildPreview.desc.buildColliders[i].q.z);
-            bw.Write(buildPreview.desc.buildColliders[i].q.w);
-            bw.Write(buildPreview.desc.buildColliders[i].radius);
-            bw.Write(buildPreview.desc.buildColliders[i].idType);
-            bw.Write(buildPreview.desc.buildColliders[i].link);
-        }
-
+        //Export the index of ItemProto and featch by LDB.items on the receiving end
         bw.Write(buildPreview.item.ID);
-        bw.Write(buildPreview.item.BuildMode);
-        bw.Write(buildPreview.item.Grade);
+
         bw.Write(buildPreview.paramCount);
         for (var i = 0; i < buildPreview.paramCount; i++)
         {

--- a/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/WarningSystem_Patch.cs
@@ -12,13 +12,28 @@ namespace NebulaPatcher.Patches.Dynamic;
 internal class WarningSystem_Patch
 {
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.NewWarningData))]
     [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.RemoveWarningData))]
     [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.WarningLogic))]
     public static bool AlterWarningData_Prefix()
     {
         //Let warningPool only be updated by packet
         return !Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(WarningSystem), nameof(WarningSystem.NewWarningData))]
+    public static void NewWarningData_Prefix(WarningSystem __instance, ref int factoryId)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return;
+        }
+
+        // Stop the code to access unreachable factory
+        factoryId = -1;
+        // Let it return a dummy WarningData pool[0]
+        __instance.warningRecycleCursor = 1;
+        __instance.warningRecycle[0] = 0;
     }
 
     [HarmonyPrefix]

--- a/NebulaWorld/Factory/BuildToolManager.cs
+++ b/NebulaWorld/Factory/BuildToolManager.cs
@@ -77,8 +77,11 @@ public class BuildToolManager : IDisposable
         {
             tmpList.AddRange(buildTool.buildPreviews);
             buildTool.buildPreviews.Clear();
-            buildTool.buildPreviews.AddRange(packet.GetBuildPreviews());
-            pos = buildTool.buildPreviews[0].lpos;
+            if (packet.TryGetBuildPreviews(out var incomingPreviews))
+            {
+                buildTool.buildPreviews.AddRange(incomingPreviews);
+                pos = buildTool.buildPreviews[0].lpos;
+            }
         }
 
         Multiplayer.Session.Factories.EventFactory = planet.factory;
@@ -123,6 +126,10 @@ public class BuildToolManager : IDisposable
                     WarningManager.DisplayTemporaryWarning(warningText, 15000);
                 }
             }
+            else
+            {
+                // Should there be check that the buildPreviews sent by client don't contain outdated objId?
+            }
 
             if (packet.BuildToolType == typeof(BuildTool_Click).ToString())
             {
@@ -134,9 +141,6 @@ public class BuildToolManager : IDisposable
             }
             else if (packet.BuildToolType == typeof(BuildTool_Addon).ToString())
             {
-                //todo:remove or replace
-                //((BuildTool_Addon)buildTool).handbp =
-                //    buildTool.buildPreviews[0]; // traffic monitors cannot be drag build atm, so its always only one.
                 ((BuildTool_Addon)buildTool).CreatePrebuilds();
             }
             else if (packet.BuildToolType == typeof(BuildTool_Inserter).ToString())
@@ -152,11 +156,13 @@ public class BuildToolManager : IDisposable
                     var previousPool = bpTool.bpPool;
 
                     // Perform the requested CreatePrebuilds();
-                    var incomingPreviews = packet.GetBuildPreviews();
-                    bpTool.bpCursor = incomingPreviews.Count;
-                    bpTool.bpPool = incomingPreviews.ToArray();
-                    bpTool.CreatePrebuilds();
-                    pos = incomingPreviews[0].lpos;
+                    if (packet.TryGetBuildPreviews(out var incomingPreviews))
+                    {
+                        bpTool.bpCursor = incomingPreviews.Count;
+                        bpTool.bpPool = incomingPreviews.ToArray();
+                        bpTool.CreatePrebuilds();
+                        pos = incomingPreviews[0].lpos;
+                    }
 
                     // Revert to previous data
                     bpTool.bpCursor = previousCursor;

--- a/NebulaWorld/Factory/FactoryManager.cs
+++ b/NebulaWorld/Factory/FactoryManager.cs
@@ -204,27 +204,6 @@ public class FactoryManager : IFactoryManager
         return prebuildRecycleCursor <= 0 ? factory.prebuildCursor + 1 : prebuildRecycle[prebuildRecycleCursor - 1];
     }
 
-    public void OnNewSetInserterPickTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
-    {
-        // 1. Client receives the build request from itself 2. Host sends the build request
-        if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor ||
-                                     Multiplayer.Session.LocalPlayer.IsHost && !IsIncomingRequest.Value))
-        {
-            Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterPickTargetPacket(objId, otherObjId, inserterId,
-                offset, pointPos, GameMain.localPlanet?.id ?? -1));
-        }
-    }
-
-    public void OnNewSetInserterInsertTarget(int objId, int otherObjId, int inserterId, int offset, Vector3 pointPos)
-    {
-        if (Multiplayer.IsActive && (Multiplayer.Session.LocalPlayer.Id == PacketAuthor ||
-                                     Multiplayer.Session.LocalPlayer.IsHost && !IsIncomingRequest.Value))
-        {
-            Multiplayer.Session.Network.SendPacketToLocalStar(new NewSetInserterInsertTargetPacket(objId, otherObjId,
-                inserterId, offset, pointPos, GameMain.localPlanet?.id ?? -1));
-        }
-    }
-
     private Locker GetPrebuildRequests(out Dictionary<PrebuildOwnerKey, ushort> prebuildRequests)
     {
         return threadSafe.PrebuildRequests.GetLocked(out prebuildRequests);


### PR DESCRIPTION
Fix WarningSystem.NewWarningData on client, which now return index-0 in warningPool as a dummy value.  
Rework CreatePrebuildsRequest serialization by sending only modelId and itemId.
Remove OnNewSetInserterPickTarget and OnNewSetInserterInsertTarget from NebulaAPI.