### PR TITLE
Disable and uncheck dark fog/enimies toggle in multiplayer

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
@@ -80,7 +80,7 @@ internal class UIGalaxySelect_Patch
             MainMenuStarID = GameMain.localStar.id;
         }
 
-#if !DEBUG
+#if RELEASE
         DisableDarkFogToggle();
 #endif
 

--- a/NebulaPatcher/Patches/Dynamic/UILoadGameWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UILoadGameWindow_Patch.cs
@@ -5,6 +5,8 @@ using NebulaModel;
 using NebulaModel.Logger;
 using NebulaNetwork;
 using NebulaWorld;
+using static NebulaPatcher.Patches.Dynamic.UIOptionWindow_Patch;
+using UnityEngine;
 
 #endregion
 
@@ -13,6 +15,8 @@ namespace NebulaPatcher.Patches.Dynamic;
 [HarmonyPatch(typeof(UILoadGameWindow))]
 internal class UILoadGameWindow_Patch
 {
+    private static Tooltip loadDisabledTooltip;
+
     [HarmonyPostfix]
     [HarmonyPatch(nameof(UILoadGameWindow.DoLoadSelectedGame))]
     public static void DoLoadSelectedGame_Postfix()
@@ -23,5 +27,47 @@ internal class UILoadGameWindow_Patch
         }
         Log.Info($"Listening server on port {Config.Options.HostPort}");
         Multiplayer.HostGame(new Server(Config.Options.HostPort, true));
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(UILoadGameWindow.OnSelectedChange))]
+    public static void OnSelectedChange_Postfix(UILoadGameWindow __instance)
+    {
+        if (!Multiplayer.IsInMultiplayerMenu)
+        {
+            RemoveLoadDisabledTooltip();
+            return;
+        }
+
+#if RELEASE
+        DisableLoadIfSaveHasCombatModeEnabled(__instance);
+#endif
+    }
+
+    private static void DisableLoadIfSaveHasCombatModeEnabled(UILoadGameWindow uiLoadGameWindow)
+    {
+        if (uiLoadGameWindow.selected?.saveName != null && (GameSave.LoadGameDesc(uiLoadGameWindow.selected.saveName)?.isCombatMode ?? false))
+        {
+            uiLoadGameWindow.loadButton.button.interactable = false;
+
+            if (loadDisabledTooltip == null)
+            {
+                loadDisabledTooltip = uiLoadGameWindow.loadButton.button.gameObject.AddComponent<Tooltip>();
+                loadDisabledTooltip.Title = "Not supported in multiplayer";
+                loadDisabledTooltip.Text = "Loading saved games with combat mode enabled is currently not supported in multiplayer.";
+            }
+        }
+        else
+        {
+            RemoveLoadDisabledTooltip();
+        }
+    }
+
+    private static void RemoveLoadDisabledTooltip()
+    {
+        if (loadDisabledTooltip != null)
+        {
+            Object.Destroy(loadDisabledTooltip);
+        }
     }
 }


### PR DESCRIPTION
This PR aims to disable and uncheck the dark for toggle when hosting (or joining) a multiplayer session

TODO:
- [x] Look into restricting hosting of savegames with dark fog enabled
- [x] Fix restoring original state so that when switching from multiplayer new game to normal new game dark fog is toggleable again
- [x] Disable this when #DEBUG is specified
- [x] Discuss tooltip wording
- [x] Cleanup