### PR TITLE
Add syncing for BattleBase

### DIFF
--- a/NebulaModel/Packets/Factory/BattleBase/BattleBaseSettingUpdatePacket.cs
+++ b/NebulaModel/Packets/Factory/BattleBase/BattleBaseSettingUpdatePacket.cs
@@ -1,0 +1,32 @@
+﻿namespace NebulaModel.Packets.Factory.BattleBase;
+
+public class BattleBaseSettingUpdatePacket
+{
+    public BattleBaseSettingUpdatePacket() { }
+
+    public BattleBaseSettingUpdatePacket(int planetId, int battleBaseId, BattleBaseSettingEvent settingEvent, float arg1)
+    {
+        PlanetId = planetId;
+        BattleBaseId = battleBaseId;
+        Event = settingEvent;
+        Arg1 = arg1;
+    }
+
+    public int PlanetId { get; set; }
+    public int BattleBaseId { get; set; }
+    public BattleBaseSettingEvent Event { get; set; }
+    public float Arg1 { get; set; }
+}
+
+public enum BattleBaseSettingEvent
+{
+    None = 0,
+    ChangeMaxChargePower = 1, //OnMaxChargePowerSliderChange
+    ToggleDroneEnabled = 2, //OnDroneButtonClick
+    ChangeDronesPriority = 3, //OnDroneButtonClick
+    ToggleCombatModuleEnabled = 4, //OnFleetButtonClick
+    ToggleAutoReconstruct = 5, //OnAutoReconstructButtonClick
+    ToggleAutoPickEnabled = 6, //OnAutoPickButtonClick
+    ChangeFleetConfig = 7, //OnFleetTypeButtonClick
+    ToggleAutoReplenishFleet = 8 //OnAutoReplenishButtonClick
+}

--- a/NebulaNetwork/PacketProcessors/Factory/BattleBase/BattleBaseSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/BattleBase/BattleBaseSettingUpdateProcessor.cs
@@ -1,0 +1,107 @@
+﻿#region
+
+using System;
+using NebulaAPI.Packets;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.BattleBase;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Factory.BattleBase;
+
+[RegisterPacketProcessor]
+internal class BattleBaseSettingUpdateProcessor : PacketProcessor<BattleBaseSettingUpdatePacket>
+{
+    protected override void ProcessPacket(BattleBaseSettingUpdatePacket packet, NebulaConnection conn)
+    {
+        var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
+        if (IsHost && factory != null)
+        {
+            if (packet.Event != BattleBaseSettingEvent.ChangeFleetConfig)
+            {
+                // Broadcast to the star system where the event planet is located
+                Multiplayer.Session.Network.SendPacketToStar(packet, factory.planet.star.id);
+            }
+            else
+            {
+                // Don't send back packet to original author because ChangeFleetConfig has been called
+                Multiplayer.Session.Network.SendPacketToStarExclude(packet, factory.planet.star.id, conn);
+            }
+        }
+
+        var pool = factory?.defenseSystem.battleBases;
+        if (pool != null && packet.BattleBaseId > 0)
+        {
+            var battleBase = pool[packet.BattleBaseId];
+
+            switch (packet.Event)
+            {
+                case BattleBaseSettingEvent.ChangeMaxChargePower:
+                    factory.powerSystem.consumerPool[battleBase.pcId].workEnergyPerTick = (long)(5000.0 * (double)packet.Arg1 + 0.5);
+                    break;
+
+                case BattleBaseSettingEvent.ToggleDroneEnabled:
+                    battleBase.constructionModule.droneEnabled = packet.Arg1 != 0f;
+                    break;
+
+                case BattleBaseSettingEvent.ChangeDronesPriority:
+                    battleBase.constructionModule.ChangeDronesPriority(factory, packet.Arg1);
+                    break;
+
+                case BattleBaseSettingEvent.ToggleCombatModuleEnabled:
+                    battleBase.combatModule.moduleEnabled = packet.Arg1 != 0f;
+                    break;
+
+                case BattleBaseSettingEvent.ToggleAutoReconstruct:
+                    battleBase.constructionModule.autoReconstruct = packet.Arg1 != 0f;
+                    break;
+
+                case BattleBaseSettingEvent.ToggleAutoPickEnabled:
+                    battleBase.autoPickEnabled = packet.Arg1 != 0f;
+                    break;
+
+                case BattleBaseSettingEvent.ChangeFleetConfig:
+                    // Copy ChangeFleetConfig without storage/inventory interactions
+                    // This may change for future ModuleFleet sycning
+                    var fleetIndex = 0;
+                    var newConfigId = (int)packet.Arg1;
+                    ref var moduleFleet = ref battleBase.combatModule.moduleFleets[fleetIndex];
+                    for (var i = 0; i < moduleFleet.fighters.Length; i++)
+                    {
+                        if (moduleFleet.fighters[i].itemId != newConfigId)
+                        {
+                            if (moduleFleet.fighters[i].count > 0)
+                            {
+                                var itemId = 0;
+                                var count = 0;
+                                moduleFleet.TakeFighterFromPort(i, ref itemId, ref count);
+                            }
+                            moduleFleet.SetItemId(i, newConfigId);
+                        }
+                    }
+                    break;
+
+                case BattleBaseSettingEvent.ToggleAutoReplenishFleet:
+                    battleBase.combatModule.autoReplenishFleet = packet.Arg1 != 0f;
+                    break;
+
+                default:
+                    Log.Warn($"BattleBaseSettingEvent: Unhandle BattleBaseSettingEvent {packet.Event}");
+                    break;
+            }
+
+            //Update UI window too if the local is viewing the current Battle Base
+            var battleBaseWindow = UIRoot.instance.uiGame.battleBaseWindow;
+            if (battleBaseWindow.battleBaseId != packet.BattleBaseId || battleBaseWindow.factory?.planetId != packet.PlanetId)
+            {
+                return;
+            }
+            battleBaseWindow.eventLock = true;
+            battleBaseWindow.OnBattleBaseIdChange();
+            battleBaseWindow.eventLock = false;
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/UIBattleBaseWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIBattleBaseWindow_Patch.cs
@@ -1,0 +1,132 @@
+﻿#region
+
+using HarmonyLib;
+using NebulaModel.Packets.Factory.BattleBase;
+using NebulaWorld;
+#pragma warning disable IDE1006
+
+#endregion
+
+namespace NebulaPatcher.Patches.Dynamic;
+
+[HarmonyPatch(typeof(UIBattleBaseWindow))]
+internal class UIBattleBaseWindow_Patch
+{
+    private static void SendEvent(UIBattleBaseWindow __instance, BattleBaseSettingEvent settingEvent, float arg)
+    {
+        // client will wait for server approve those interactions
+        Multiplayer.Session.Network.SendPacket(new BattleBaseSettingUpdatePacket(
+            __instance.factory.planetId, __instance.battleBaseId,
+            settingEvent, arg));
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnMaxChargePowerSliderChange))]
+
+    public static bool OnMaxChargePowerSliderChange_Prefix(UIBattleBaseWindow __instance, float arg0)
+    {
+        if (!Multiplayer.IsActive || __instance.battleBaseId == 0 || __instance.factory == null || __instance.battleBase.id != __instance.battleBaseId)
+        {
+            return true;
+        }
+        if (__instance.eventLock)
+        {
+            // Prevent ping-pong of sending update packets
+            return false;
+        }
+        SendEvent(__instance, BattleBaseSettingEvent.ChangeMaxChargePower, arg0);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnDroneButtonClick))]
+    public static bool OnDroneButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = __instance.constructionModule.droneEnabled ? 0f : 1f;
+        SendEvent(__instance, BattleBaseSettingEvent.ToggleDroneEnabled, arg);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnDronePriorityButtonClick))]
+    public static bool OnDronePriorityButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var ratio = __instance.constructionModule.dronePriorConstructRatio;
+        var newRatio = ratio < 0.25f ? 0.5f : (ratio < 0.75f ? 1f : 0f);
+        SendEvent(__instance, BattleBaseSettingEvent.ChangeDronesPriority, newRatio);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnFleetButtonClick))]
+    public static bool OnFleetButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = __instance.combatModule.moduleEnabled ? 0f : 1f;
+        SendEvent(__instance, BattleBaseSettingEvent.ToggleCombatModuleEnabled, arg);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnAutoReconstructButtonClick))]
+    public static bool OnAutoReconstructButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = __instance.constructionModule.autoReconstruct ? 0f : 1f;
+        SendEvent(__instance, BattleBaseSettingEvent.ToggleAutoReconstruct, arg);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnAutoPickButtonClick))]
+    public static bool OnAutoPickButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = __instance.battleBase.autoPickEnabled ? 0f : 1f;
+        SendEvent(__instance, BattleBaseSettingEvent.ToggleAutoPickEnabled, arg);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnFleetTypeButtonClick))]
+    public static bool OnFleetTypeButtonClick_Prefix(UIBattleBaseWindow __instance, int obj)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = ItemProto.kFighterGroundIds[obj];
+        SendEvent(__instance, BattleBaseSettingEvent.ChangeFleetConfig, arg);
+        return true; // Let local handles the storage/inventory interactions and broadcast the changes
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIBattleBaseWindow.OnAutoReplenishButtonClick))]
+    public static bool OnAutoReplenishButtonClick_Prefix(UIBattleBaseWindow __instance)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return true;
+        }
+        var arg = __instance.combatModule.autoReplenishFleet ? 0f : 1f;
+        SendEvent(__instance, BattleBaseSettingEvent.ToggleAutoReplenishFleet, arg);
+        return Multiplayer.Session.LocalPlayer.IsHost;
+    }
+}


### PR DESCRIPTION
Sync for UIBattleBaseWindow changes of Battle Analysis Base
Most events are sent to host first and then broadcast to other players to reduce the time difference.

The event I'm not sure about is ChangeFleetConfig. Should it be handled in UIBattleBaseWindow patch or lower level?
It may need to change depending on how `ModuleFleet` syncing implement in the future.