### PR TITLE
Rework power tower syncing #2

### DIFF
--- a/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
@@ -17,9 +17,14 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
     {
         if (packet.PlanetId == -1)
         {
-            // When a player disconnect, clear all records and restart
+            // When a player connet, disconnect, or leave planet, clear all records and restart
             Multiplayer.Session.PowerTowers.LocalChargerIds.Clear();
             Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Clear();
+            if (IsHost)
+            {
+                // Broadcast the leave planet event to other players 
+                Multiplayer.Session.Network.SendPacket(packet);
+            }
             return;
         }
 
@@ -31,11 +36,27 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
         var hashId = ((long)packet.PlanetId << 32) | (long)packet.NodeId;
         if (packet.Charging)
         {
-            Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Add(hashId);
+            if (Multiplayer.Session.PowerTowers.RemoteChargerHashIds.TryGetValue(hashId, out var playerCount))
+            {
+                Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] = playerCount + 1;
+            }
+            else
+            {
+                Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Add(hashId, 1);
+            }
+            NebulaModel.Logger.Log.Debug($"Add remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId]}");
         }
         else
         {
-            Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Remove(hashId);
+            if (Multiplayer.Session.PowerTowers.RemoteChargerHashIds.TryGetValue(hashId, out var playerCount))
+            {
+                NebulaModel.Logger.Log.Debug($"Remove remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] - 1}");
+                Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] = playerCount - 1;
+                if (playerCount <= 1)
+                {
+                    Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Remove(hashId);
+                }
+            }
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
@@ -17,7 +17,7 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
     {
         if (packet.PlanetId == -1)
         {
-            // When a player connet, disconnect, or leave planet, clear all records and restart
+            // When a player connects, disconnects, or leaves planet, clear all records and restart
             Multiplayer.Session.PowerTowers.LocalChargerIds.Clear();
             Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Clear();
             if (IsHost)
@@ -48,14 +48,15 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
         }
         else
         {
-            if (Multiplayer.Session.PowerTowers.RemoteChargerHashIds.TryGetValue(hashId, out var playerCount))
+            if (!Multiplayer.Session.PowerTowers.RemoteChargerHashIds.TryGetValue(hashId, out var playerCount))
             {
-                NebulaModel.Logger.Log.Debug($"Remove remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] - 1}");
-                Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] = playerCount - 1;
-                if (playerCount <= 1)
-                {
-                    Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Remove(hashId);
-                }
+                return;
+            }
+            NebulaModel.Logger.Log.Debug($"Remove remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] - 1}");
+            Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] = playerCount - 1;
+            if (playerCount <= 1)
+            {
+                Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Remove(hashId);
             }
         }
     }

--- a/NebulaNetwork/PlayerManager.cs
+++ b/NebulaNetwork/PlayerManager.cs
@@ -322,7 +322,6 @@ public class PlayerManager : IPlayerManager
             {
                 availablePlayerIds.Enqueue(player.Id);
             }
-            Multiplayer.Session.PowerTowers.OnClientDisconnect();
             Multiplayer.Session.Statistics.UnRegisterPlayer(player.Id);
             Multiplayer.Session.DysonSpheres.UnRegisterPlayer(conn);
 

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -417,6 +417,7 @@ internal class GameData_Patch
         //Players should clear the list of drone orders of other players when they leave the planet
         if (Multiplayer.IsActive)
         {
+            Multiplayer.Session.PowerTowers.ResetAndBroadcast();
             //todo:replace
             //GameMain.mainPlayer.mecha.droneLogic.serving.Clear();
         }

--- a/NebulaPatcher/Patches/Transpilers/PowerSystem_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/PowerSystem_Transpiler.cs
@@ -23,116 +23,131 @@ internal class PowerSystem_Transpiler
     {
         var codeInstructions = instructions as CodeInstruction[] ?? instructions.ToArray();
 
-        // Get the variable of mecha power coefficient:
-        // num7 = Mathf.Pow(Mathf.Clamp01((float)(1.0 - mainPlayer.mecha.coreEnergy / mainPlayer.mecha.coreEnergyCap) * 10f), 0.75f);
-        var codeMatcher = new CodeMatcher(codeInstructions, iLGenerator)
-            .MatchForward(true,
-                new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Mathf), nameof(Mathf.Pow))),
-                new CodeMatch(OpCodes.Stloc_S));
-        var coreEnergyRatioCI = new CodeInstruction(OpCodes.Ldloc_S, codeMatcher.Operand);
-
-        /* Overwrite the logic that set the power charger requiredEnergy and replace with our own.
-        from:
-	        if (this.nodePool[id].id == id && this.nodePool[id].isCharger)
-	        {
-		        if (this.nodePool[id].coverRadius <= 20f)
-		        {
-			        ...
-		        }
-		        else
-		        {
-			        this.nodePool[id].requiredEnergy = this.nodePool[id].idleEnergyPerTick;
-		        }
-		        long num21 = (long)this.nodePool[id].requiredEnergy;
-		        num11 += num21;
-		        num2 += num21;
-	        }
-        to:
-            if (this.nodePool[id].id == id && this.nodePool[id].isCharger)
-	        {
-                if (this.nodePool[id].coverRadius <= 20f)
-		        {			        
-		            SetChargerRequriePower(this, id, num7); //replace
-		        }
-		        else
-		        {
-			        this.nodePool[id].requiredEnergy = this.nodePool[id].idleEnergyPerTick;
-		        }
-		        long num21 = (long)this.nodePool[id].requiredEnergy;
-		        num11 += num21;
-		        num2 += num21;
-	        }
-        */
-        codeMatcher
-            .MatchForward(false, new CodeMatch(i => i.opcode == OpCodes.Call && ((MethodInfo)i.operand).Name == "MoveNext"))
-            .MatchBack(true,
-                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.idleEnergyPerTick))),
-                new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.requiredEnergy))),
-                new CodeMatch(OpCodes.Ldarg_0));
-        if (codeMatcher.IsInvalid)
+        try
         {
-            Log.Error("PowerSystem_GameTick_Transpiler 1 failed. Mod version not compatible with game version.");
-            return codeInstructions;
-        }
-        codeMatcher.CreateLabel(out var label);
-        var nodeIdCI = codeMatcher.InstructionAt(-4);
+            /*  Get the variable of mecha power coefficient:
+             	lock (mecha)
+		        {
+			        num7 = Mathf.Pow(Mathf.Clamp01((float)(1.0 - mainPlayer.mecha.coreEnergy / mainPlayer.mecha.coreEnergyCap) * 10f), 0.75f);
+		        }
+            */
+            var codeMatcher = new CodeMatcher(codeInstructions, iLGenerator)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Mathf), nameof(Mathf.Pow))),
+                    new CodeMatch(OpCodes.Stloc_S),
+                    new CodeMatch(OpCodes.Leave));
+            var coreEnergyRatioCI = new CodeInstruction(OpCodes.Ldloc_S, codeMatcher.InstructionAt(-1).operand);
 
-        codeMatcher
-            .MatchBack(true, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.isCharger))))
-            .MatchForward(true, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.coverRadius))));
-        if (codeMatcher.IsInvalid)
-        {
-            Log.Error("PowerSystem_GameTick_Transpiler 2 failed. Mod version not compatible with game version.");
-            return codeInstructions;
-        }
-        codeMatcher.Advance(3)
-            .Insert(
-                new CodeInstruction(OpCodes.Ldarg_0),
-                nodeIdCI,
-                coreEnergyRatioCI,
-                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PowerSystem_Transpiler), nameof(SetChargerRequiredPower))),
-                new CodeInstruction(OpCodes.Br_S, label)
-            );
+            /* Overwrite the logic that set the power charger requiredEnergy and replace with our own.
+            from:
+                if (this.nodePool[id].id == id && this.nodePool[id].isCharger)
+                {
+                    if (this.nodePool[id].coverRadius <= 20f)
+                    {
+                        ...
+                    }
+                    else
+                    {
+                        this.nodePool[id].requiredEnergy = this.nodePool[id].idleEnergyPerTick;
+                    }
+                    long num21 = (long)this.nodePool[id].requiredEnergy;
+                    num11 += num21;
+                    num2 += num21;
+                }
+            to:
+                if (this.nodePool[id].id == id && this.nodePool[id].isCharger)
+                {
+                    if (this.nodePool[id].coverRadius <= 20f)
+                    {			        
+                        SetChargerRequriePower(this, id, num7); //replace
+                    }
+                    else
+                    {
+                        this.nodePool[id].requiredEnergy = this.nodePool[id].idleEnergyPerTick;
+                    }
+                    long num21 = (long)this.nodePool[id].requiredEnergy;
+                    num11 += num21;
+                    num2 += num21;
+                }
+            */
+            codeMatcher
+                .MatchForward(false, new CodeMatch(i => i.opcode == OpCodes.Call && ((MethodInfo)i.operand).Name == "MoveNext"))
+                .MatchBack(true,
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.idleEnergyPerTick))),
+                    new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.requiredEnergy))),
+                    new CodeMatch(OpCodes.Ldarg_0));
+            if (codeMatcher.IsInvalid)
+            {
+                Log.Error("PowerSystem_GameTick_Transpiler 1 failed. Mod version not compatible with game version.");
+                return codeInstructions;
+            }
+            codeMatcher.CreateLabel(out var label);
+            var nodeIdCI = codeMatcher.InstructionAt(-4);
 
-        // Check if chargers are local before adding the energy to the mecha
-        // from: if (this.nodePool[num75].id == num75)
-        // get:  num75 (nodeId)
-        codeMatcher.End()
-            .MatchBack(true,
-                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.id))),
-                new CodeMatch(OpCodes.Ldloc_S));
-        if (codeMatcher.IsInvalid)
-        {
-            Log.Error("PowerSystem_GameTick_Transpiler 3 failed. Mod version not compatible with game version.");
-            return codeInstructions;
-        }
-        var loadNodeIdInstruction = codeMatcher.InstructionAt(0);
+            codeMatcher
+                .MatchBack(true, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.isCharger))))
+                .MatchForward(true, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.coverRadius))));
+            if (codeMatcher.IsInvalid)
+            {
+                Log.Error("PowerSystem_GameTick_Transpiler 2 failed. Mod version not compatible with game version.");
+                return codeInstructions;
+            }
+            codeMatcher.Advance(3)
+                .Insert(
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    nodeIdCI,
+                    coreEnergyRatioCI,
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PowerSystem_Transpiler), nameof(SetChargerRequiredPower))),
+                    new CodeInstruction(OpCodes.Br_S, label)
+                );
 
-        /*
-        from:
-            if (num77 <= 0 || entityAnimPool[entityId5].state != 2U)
-        to:
-            if (num77 <= 0 || entityAnimPool[entityId5].state != 2U || !IsNotLocal(this, num75))
-        */
-        codeMatcher.MatchForward(true,
-                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(AnimData), nameof(AnimData.state))),
-                new CodeMatch(OpCodes.Ldc_I4_2),
+            // Check if chargers are local before adding the energy to the mecha
+            // from: if (this.nodePool[num75].id == num75)
+            // get:  num75 (nodeId)
+            codeMatcher.End()
+                .MatchBack(true,
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PowerNodeComponent), nameof(PowerNodeComponent.id))),
+                    new CodeMatch(OpCodes.Ldloc_S),
+                    new CodeMatch(OpCodes.Bne_Un));
+            if (codeMatcher.IsInvalid)
+            {
+                Log.Error("PowerSystem_GameTick_Transpiler 3 failed. Mod version not compatible with game version.");
+                return codeInstructions;
+            }
+            var loadNodeIdInstruction = codeMatcher.InstructionAt(-1);
+
+            /*
+            from:
+                if (num77 <= 0 || entityAnimPool[entityId5].state != 2U)
+            to:
+                if (num77 <= 0 || entityAnimPool[entityId5].state != 2U || !IsNotLocal(this, num75))
+            */
+            codeMatcher.MatchForward(true,
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(AnimData), nameof(AnimData.state))),
+                    new CodeMatch(OpCodes.Ldc_I4_2),
                 new CodeMatch(OpCodes.Bne_Un));
-        if (codeMatcher.IsInvalid)
+            if (codeMatcher.IsInvalid)
+            {
+                Log.Error("PowerSystem_GameTick_Transpiler 4 failed. Mod version not compatible with game version.");
+                return codeInstructions;
+            }
+
+            codeMatcher
+                 .Insert(
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    loadNodeIdInstruction,
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PowerSystem_Transpiler), nameof(IsNotLocal))),
+                    new CodeInstruction(OpCodes.Or)
+                );
+
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (System.Exception e)
         {
-            Log.Error("PowerSystem_GameTick_Transpiler 4 failed. Mod version not compatible with game version.");
+            Log.Error("PowerSystem_GameTick_Transpiler failed. Power chargers will not be in synced.");
+            Log.Error(e);
             return codeInstructions;
         }
-
-        codeMatcher
-             .Insert(
-                new CodeInstruction(OpCodes.Ldarg_0),
-                loadNodeIdInstruction,
-                new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(PowerSystem_Transpiler), nameof(IsNotLocal))),
-                new CodeInstruction(OpCodes.Or)
-            );
-
-        return codeMatcher.InstructionEnumeration();
     }
 
     private static bool IsNotLocal(PowerSystem powerSystem, int nodeId)
@@ -162,6 +177,7 @@ internal class PowerSystem_Transpiler
 
             if (dist <= maxDist && coreEnergyRatio > 0)
             {
+                // Mecha in range and require energy
                 if (Multiplayer.IsActive)
                 {
                     if (!Multiplayer.Session.PowerTowers.LocalChargerIds.Contains(powerNode.id))
@@ -200,8 +216,8 @@ internal class PowerSystem_Transpiler
 
         if (Multiplayer.IsActive)
         {
-            var hashId = (long)planetId << 32 | (long)powerNode.id;
-            if (Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Contains(hashId))
+            var hashId = ((long)planetId << 32) | (long)powerNode.id;
+            if (Multiplayer.Session.PowerTowers.RemoteChargerHashIds.ContainsKey(hashId))
             {
                 // This charger is used by remote player
                 powerNode.requiredEnergy = powerNode.workEnergyPerTick;

--- a/NebulaPatcher/Patches/Transpilers/UIPowerNodeWindow_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIPowerNodeWindow_Transpiler.cs
@@ -1,0 +1,70 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Transpilers;
+
+[HarmonyPatch(typeof(UIPowerNodeWindow))]
+internal class UIPowerNodeWindow_Transpiler
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(UIPowerNodeWindow._OnUpdate))]
+    public static IEnumerable<CodeInstruction> OnUpdate_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var codeInstructions = instructions as CodeInstruction[] ?? instructions.ToArray();
+        try
+        {
+
+            // from: if (powerNodeComponent.requiredEnergy > powerNodeComponent.idleEnergyPerTick && this.player.mecha.energyChanges[2] > 0.0)
+            // to:   if (powerNodeComponent.requiredEnergy > powerNodeComponent.idleEnergyPerTick)
+            var codeMatcher = new CodeMatcher(codeInstructions)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld),
+                    new CodeMatch(i => i.opcode == OpCodes.Callvirt && ((MethodInfo)i.operand).Name == "get_mecha"),
+                    new CodeMatch(i => i.opcode == OpCodes.Ldfld && ((FieldInfo)i.operand).Name == "energyChanges")
+                )
+                .RemoveInstructions(8);
+
+            // from: this.chargeStateValueText.text = "正在充电".Translate();
+            // to:   this.chargeStateValueText.text = ChargeStateText("正在充电".Translate());
+            codeMatcher.MatchForward(false,
+                    new CodeMatch(i => i.opcode == OpCodes.Ldfld && ((FieldInfo)i.operand).Name == "chargeStateValueText"))
+                .MatchForward(false,
+                    new CodeMatch(i => i.opcode == OpCodes.Callvirt && ((MethodInfo)i.operand).Name == "set_text")
+                )
+                .Insert(
+                    new CodeInstruction(OpCodes.Ldarg_0),
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(UIPowerNodeWindow_Transpiler), nameof(ChargeStateText)))
+                );
+
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (Exception e)
+        {
+            Log.Warn("UIPowerNodeWindow._OnUpdate Transpiler failed. Charger UI will be unchanged.");
+            Log.Warn(e);
+            return codeInstructions;
+        }
+    }
+
+    private static string ChargeStateText(string oringalValue, UIPowerNodeWindow powerNodeWindow)
+    {
+        if (!Multiplayer.IsActive)
+        {
+            return oringalValue;
+        }
+        var hashId = ((long)powerNodeWindow.factory.planetId << 32) | (long)powerNodeWindow.nodeId;
+        Multiplayer.Session.PowerTowers.RemoteChargerHashIds.TryGetValue(hashId, out var count);
+        return oringalValue + '[' + count + ']';
+    }
+}

--- a/NebulaWorld/Factory/PowerTowerManager.cs
+++ b/NebulaWorld/Factory/PowerTowerManager.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using NebulaModel.Packets.Factory.PowerTower;
+#pragma warning disable IDE1006
 
 #endregion
 
@@ -10,8 +11,8 @@ namespace NebulaWorld.Factory;
 
 public class PowerTowerManager : IDisposable
 {
-    public HashSet<int> LocalChargerIds = [];
-    public HashSet<long> RemoteChargerHashIds = [];
+    public HashSet<int> LocalChargerIds = []; // nodeId
+    public Dictionary<long, int> RemoteChargerHashIds = []; // (plaentId << 32 | nodeId), playerCount
 
     public void Dispose()
     {
@@ -24,12 +25,12 @@ public class PowerTowerManager : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    public void OnClientDisconnect()
+    public void ResetAndBroadcast()
     {
         // Procast event to reset all
         LocalChargerIds.Clear();
         RemoteChargerHashIds.Clear();
-        Multiplayer.Session.Network.SendPacketToLocalStar(new PowerTowerChargerUpdate(
+        Multiplayer.Session.Network.SendPacket(new PowerTowerChargerUpdate(
             -1,
             0,
             false));

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -216,6 +216,8 @@ public class SimulatedWorld : IDisposable
             GameMain.mainPlayer.sandCount += player.Data.Mecha.SandCount;
             Multiplayer.Session.Network.SendPacket(new PlayerSandCount(GameMain.mainPlayer.sandCount));
         }
+        // Reset local and remote chargers ids to recalculate and broadcast the current ids to new player
+        Multiplayer.Session.PowerTowers.ResetAndBroadcast();
 
         // (Host only) Trigger when a new client added to connected players
         Log.Info($"Client{player.Data.PlayerId} - {player.Data.Username} joined");
@@ -239,6 +241,8 @@ public class SimulatedWorld : IDisposable
             UIRoot.instance.uiGame.OnSandCountChanged(GameMain.mainPlayer.sandCount, -player.Data.Mecha.SandCount);
             Multiplayer.Session.Network.SendPacket(new PlayerSandCount(GameMain.mainPlayer.sandCount));
         }
+        // Reset local and remote chargers ids to remove the ids used by the disconnected player
+        Multiplayer.Session.PowerTowers.ResetAndBroadcast();
 
         // (Host only) Trigger when a connected client leave the game
         Log.Info($"Client{player.Data.PlayerId} - {player.Data.Username} left");


### PR DESCRIPTION
Continue #627 
- Change `RemoteChargerHashIds` to type `Dictionary<long, int>` to store charger hashId and how many players are using it to charge mecha.
- Whenever a player connects, disconnects, or leaves the planet, it will broadcast the reset event to let all players clear the current records of chargers and recalculate the local and remote charger IDs.  
- Enhance the power charger window to properly show the status of a working charger that is not used by the local player, and display how many other players are using it.

TODO: Reset the charger event too when the mecha is dead.