### PR TITLE
Implement gift command

### DIFF
--- a/NebulaAPI/GameState/INetworkProvider.cs
+++ b/NebulaAPI/GameState/INetworkProvider.cs
@@ -46,5 +46,10 @@ public interface INetworkProvider : IDisposable
     /// </summary>
     void SendPacketToStarExclude<T>(T packet, int starId, INebulaConnection exclude) where T : class, new();
 
+    /// <summary>
+    ///     Send packet to Client directly (If possible) or indirectly by relaying via host (If Client is not directly reachable)
+    /// </summary>
+    void SendPacketToClient<T>(T packet, string clientUsername) where T : class, new ();
+
     void Update();
 }

--- a/NebulaModel/DataStructures/Chat/ChatCommandGiftType.cs
+++ b/NebulaModel/DataStructures/Chat/ChatCommandGiftType.cs
@@ -1,0 +1,8 @@
+﻿namespace NebulaModel.DataStructures.Chat;
+
+public enum ChatCommandGiftType
+{
+    Soil = 0, // TODO: Since Soil Pile (item id 1099 ) is also an item, we can probably remove this all together and just use Item
+    Item = 1,
+    Energy = 2
+}

--- a/NebulaModel/NetworkProvider.cs
+++ b/NebulaModel/NetworkProvider.cs
@@ -38,6 +38,9 @@ public abstract class NetworkProvider : INetworkProvider
     public abstract void SendPacketToStarExclude<T>(T packet, int starId, INebulaConnection exclude)
         where T : class, new();
 
+    public abstract void SendPacketToClient<T>(T packet, string clientUsername)
+        where T : class, new();
+
     public abstract void Update();
 
     public abstract void Start();

--- a/NebulaModel/Packets/Chat/ChatCommandGiftPacket.cs
+++ b/NebulaModel/Packets/Chat/ChatCommandGiftPacket.cs
@@ -1,0 +1,21 @@
+﻿using NebulaModel.DataStructures.Chat;
+
+namespace NebulaModel.Packets.Chat;
+
+public class ChatCommandGiftPacket
+{
+    public ChatCommandGiftPacket() { }
+
+    public ChatCommandGiftPacket(string sender, string recipient, ChatCommandGiftType type, long quantity)
+    {
+        SenderUsername = sender;
+        RecipientUsername = recipient;
+        Type = type;
+        Quantity = quantity;
+    }
+
+    public string SenderUsername { get; set; }
+    public string RecipientUsername { get; set; }
+    public ChatCommandGiftType Type { get; set; }
+    public long Quantity { get; set; }
+}

--- a/NebulaModel/Packets/Routers/ClientRelayPacket.cs
+++ b/NebulaModel/Packets/Routers/ClientRelayPacket.cs
@@ -1,0 +1,15 @@
+﻿namespace NebulaModel.Packets.Routers;
+
+public class ClientRelayPacket
+{
+    public ClientRelayPacket() { }
+
+    public ClientRelayPacket(byte[] packetObject, string clientUsername)
+    {
+        PacketObject = packetObject;
+        ClientUsername = clientUsername;
+    }
+
+    public byte[] PacketObject { get; set; }
+    public string ClientUsername { get; set; }
+}

--- a/NebulaNetwork/Client.cs
+++ b/NebulaNetwork/Client.cs
@@ -188,6 +188,11 @@ public class Client : NetworkProvider, IClient
         throw new NotImplementedException();
     }
 
+    public override void SendPacketToClient<T>(T packet, string clientUsername)
+    {
+        serverConnection?.SendPacket(new ClientRelayPacket(PacketProcessor.Write(packet), clientUsername));
+    }
+
     public override void Update()
     {
         PacketProcessor.ProcessPacketQueue();

--- a/NebulaNetwork/PacketProcessors/Chat/ChatCommandGiftProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/ChatCommandGiftProcessor.cs
@@ -1,0 +1,72 @@
+﻿#region
+
+using System;
+using NebulaAPI.Packets;
+using NebulaModel.DataStructures.Chat;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Chat;
+using NebulaWorld;
+using NebulaWorld.Chat.Commands;
+using NebulaWorld.MonoBehaviours.Local.Chat;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Chat;
+
+[RegisterPacketProcessor]
+internal class ChatCommandGiftProcessor : PacketProcessor<ChatCommandGiftPacket>
+{
+    protected override void ProcessPacket(ChatCommandGiftPacket packet, NebulaConnection conn)
+    {
+
+        //window.SendLocalChatMessage("Invalid gift type".Translate(), ChatMessageType.CommandErrorMessage);
+
+        switch (packet.Type)
+        {
+            case ChatCommandGiftType.Soil:
+                var mainPlayer = GameMain.data.mainPlayer;
+                lock (mainPlayer)
+                {
+                    mainPlayer.SetSandCount(mainPlayer.sandCount + packet.Quantity);
+                    // TODO: Do we need to do something with soil sync?
+                }
+                ChatManager.Instance.SendChatMessage($"[{DateTime.Now:HH:mm}] {packet.SenderUsername} gifted you {packet.Quantity} soil", ChatMessageType.SystemInfoMessage);
+                break;
+            // TODO: Implement Item and Energy variants.
+            default:
+                return;
+        }
+
+        // TODO: Logic for adding the soil, items, energy etc (restransmission logic no longer needed with the ClientRelayPacket
+
+        //if (IsClient)
+        //{
+        //    WhisperCommandHandler.SendWhisperToLocalPlayer(packet.SenderUsername, packet.Message);
+        //}
+        //else
+        //{
+        //    // two cases, simplest is that whisper is meant for host
+        //    if (Multiplayer.Session.LocalPlayer.Data.Username == packet.RecipientUsername)
+        //    {
+        //        WhisperCommandHandler.SendWhisperToLocalPlayer(packet.SenderUsername, packet.Message);
+        //        return;
+        //    }
+
+        //    // second case, relay message to recipient
+        //    var recipient = Multiplayer.Session.Network
+        //        .PlayerManager.GetConnectedPlayerByUsername(packet.RecipientUsername);
+        //    if (recipient == null)
+        //    {
+        //        Log.Warn($"Recipient not found {packet.RecipientUsername}");
+        //        var sender = Multiplayer.Session.Network.PlayerManager.GetPlayer(conn);
+        //        sender.SendPacket(new ChatCommandWhisperPacket("SYSTEM".Translate(), packet.SenderUsername,
+        //            string.Format("User not found {0}".Translate(), packet.RecipientUsername)));
+        //        return;
+        //    }
+
+        //    recipient.SendPacket(packet);
+        //}
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Routers/ClientRelayProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Routers/ClientRelayProcessor.cs
@@ -1,0 +1,67 @@
+﻿#region
+
+using NebulaAPI.GameState;
+using NebulaAPI.Packets;
+using NebulaModel;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Routers;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Routers;
+
+[RegisterPacketProcessor]
+internal class ClientRelayProcessor : PacketProcessor<ClientRelayPacket>
+{
+    private readonly IPlayerManager playerManager;
+
+    public ClientRelayProcessor()
+    {
+        playerManager = Multiplayer.Session.Network.PlayerManager;
+    }
+
+    protected override void ProcessPacket(ClientRelayPacket packet, NebulaConnection conn)
+    {
+        // TODO: check if this player null check is required
+        var player = playerManager.GetPlayer(conn);
+        if (player == null || packet.PacketObject == null)
+        {
+            return;
+        }
+
+        // If the processor is either host or client and the recipient is the processor unwrap and process the packet
+        // (This happens in the case that either client -> host or host -> client sends this packet directly,
+        // as you do not want manually account for the sender recipient relation when using this packet we have to handle this case as wel)
+        if (Multiplayer.Session.LocalPlayer.Data.Username == packet.ClientUsername)
+        {
+            //Process the packet on the host
+            // NOTE: Since PacketProcessor is not part of INetworkProvider this will not work if we ever swap it out with another network provider that does not expose this
+            // However StarBroadcastProcessor and PlanetBroadcastProcessor also do this in a similar manner so I think it is fine for now
+            ((NetworkProvider)Multiplayer.Session.Network).PacketProcessor
+                .EnqueuePacketForProcessing(packet.PacketObject, conn);
+            return;
+        }
+
+        // If the processor is client and not the recipient, do nothing
+        if (IsClient)
+        {
+            return;
+        }
+
+        // If the processor is the host and not the recipient, unwrap and relay packet to recipient client
+        var recipient = Multiplayer.Session.Network
+            .PlayerManager.GetConnectedPlayerByUsername(packet.ClientUsername);
+        if (recipient == null)
+        {
+            Log.Warn($"Could not relay packet because client was not found {packet.ClientUsername}");
+
+            // TODO: We might want to communicate back to the sender that the relaying failed
+            return;
+        }
+
+        recipient.Connection.SendRawPacket(packet.PacketObject);
+    }
+}

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -244,6 +244,18 @@ public class Server : NetworkProvider, IServer
         PlayerManager.SendPacketToStarExcept(packet, starId, exclude);
     }
 
+    public override void SendPacketToClient<T>(T packet, string clientUsername)
+    {
+        var recipient = PlayerManager.GetConnectedPlayerByUsername(clientUsername);
+        if (recipient == null)
+        {
+            Log.Warn($"Could not send packet to client, Recipient not found {clientUsername}");
+            return;
+        }
+
+        recipient.SendPacket(packet);
+    }
+
     public override void Update()
     {
         PacketProcessor.ProcessPacketQueue();

--- a/NebulaWorld/Chat/ChatCommandRegistry.cs
+++ b/NebulaWorld/Chat/ChatCommandRegistry.cs
@@ -27,6 +27,7 @@ public static class ChatCommandRegistry
         RegisterCommand("system", new SystemCommandHandler(), "s");
         RegisterCommand("reconnect", new ReconnectCommandHandler(), "r");
         RegisterCommand("server", new ServerCommandHandler());
+        RegisterCommand("gift", new GiftCommandHandler(), "g");
     }
 
     private static void RegisterCommand(string commandName, IChatCommandHandler commandHandlerHandler, params string[] aliases)

--- a/NebulaWorld/Chat/Commands/GiftCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/GiftCommandHandler.cs
@@ -1,0 +1,100 @@
+﻿#region
+
+using NebulaModel.DataStructures.Chat;
+using NebulaModel.Packets.Chat;
+using NebulaWorld.MonoBehaviours.Local.Chat;
+
+#endregion
+
+namespace NebulaWorld.Chat.Commands;
+
+public class GiftCommandHandler : IChatCommandHandler
+{
+    public void Execute(ChatWindow window, string[] parameters)
+    {
+        if (parameters.Length < 3)
+        {
+            throw new ChatCommandUsageException("Not enough arguments!".Translate());
+        }
+
+        var senderUsername = Multiplayer.Session?.LocalPlayer?.Data?.Username ?? "UNKNOWN";
+        if (senderUsername == "UNKNOWN" || Multiplayer.Session == null || Multiplayer.Session.LocalPlayer == null)
+        {
+            window.SendLocalChatMessage("Invalid sender (not connected), can't send gift".Translate(), ChatMessageType.CommandErrorMessage);
+            return;
+        }
+
+        // TODO: Add support for using id instead of username
+        var recipientUsername = parameters[0];
+        if (senderUsername == recipientUsername)
+        {
+            window.SendLocalChatMessage("Invalid recipient (self), can't send gift".Translate(), ChatMessageType.CommandErrorMessage);
+            return;
+        }
+        //var fullMessageBody = string.Join(" ", parameters.Skip(1));
+        // first echo what the player typed so they know something actually happened
+        //ChatManager.Instance.SendChatMessage($"[{DateTime.Now:HH:mm}] [To: {recipientUserName}] : {fullMessageBody}",
+        //    ChatMessageType.PlayerMessage);
+
+        ChatCommandGiftType type;
+        switch (parameters[1])
+        {
+            case "soil":
+            case "sand":
+            case "s":
+                type = ChatCommandGiftType.Soil;
+                break;
+            // TODO: Implement Item and Energy variants.
+            default:
+                window.SendLocalChatMessage("Invalid gift type, can't send gift".Translate(), ChatMessageType.CommandErrorMessage);
+                return;
+        }
+
+        long quantity;
+        if (!long.TryParse(parameters[2], out quantity) || quantity == 0)
+        {
+            window.SendLocalChatMessage("Invalid gift quantity, can't send gift".Translate(), ChatMessageType.CommandErrorMessage);
+            return;
+        }
+
+        // Validate that you acctually have the required soil/items/energy to gift
+        switch (type)
+        {
+            case ChatCommandGiftType.Soil:
+                var mainPlayer = GameMain.data.mainPlayer;
+                lock (mainPlayer)
+                {
+                    if (mainPlayer.sandCount < quantity)
+                    {
+                        window.SendLocalChatMessage("You dont have enough soil to send, can't send gift".Translate(), ChatMessageType.CommandErrorMessage);
+                        return;
+                    }
+
+                    mainPlayer.SetSandCount(mainPlayer.sandCount - quantity);
+                    // TODO: Do we need to do something with soil sync?
+                }
+                break;
+                // TODO: Implement Item and Energy variants.
+        }
+
+        var packet = new ChatCommandGiftPacket(senderUsername, recipientUsername, type, quantity);
+        Multiplayer.Session.Network.SendPacketToClient(packet, recipientUsername);
+    }
+
+    public string GetDescription()
+    {
+        return string.Format("Send gift to player. Use /who for valid user names. Valid types are soil (s), item (i), energy (e)".Translate());
+    }
+
+    public string[] GetUsage()
+    {
+        return ["<player> <type> <quantity>"];
+    }
+
+    // TODO: We should add logic here that acctually adds the gifted materials (and devise something to substract the materials)
+    //public static void SendWhisperToLocalPlayer(string sender, string mesageBody)
+    //{
+    //    ChatManager.Instance.SendChatMessage($"[{DateTime.Now:HH:mm}] [{sender} whispered] : {mesageBody}",
+    //        ChatMessageType.PlayerMessagePrivate);
+    //}
+}

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NebulaModel;
 using NebulaModel.DataStructures.Chat;
 using NebulaModel.Utils;
@@ -144,7 +145,13 @@ public class ChatWindow : MonoBehaviour
 
         if (chatBox.text.StartsWith(ChatCommandRegistry.CommandPrefix))
         {
-            var arguments = chatBox.text.Substring(1).Split(' ');
+            //var arguments = chatBox.text.Substring(1).Split(' ');
+            // this handles quoted arguments and supports first lvl escaping using \"
+            var arguments = Regex.Matches(chatBox.text.Substring(1), @"(?<!\\)"".+?(?<!\\)""|[^ ]+")
+                .Cast<Match>()
+                .Select(m => Regex.Replace(m.Value, @"^(?<!\\)""|(?<!\\)""$", ""))
+                .ToArray();
+
             if (arguments.Length > 0)
             {
                 var commandName = arguments[0];


### PR DESCRIPTION
Notable changes:
- Chat commands arguments now support double quoted grouping and first lvl escaping using \"
- Added gift command
- Made changes to the INetworkProvider interface to include a SendPacketToClient method and implemented it so it can send a packet from client to client without having to explicitly route it through the host (this is abstracted away)

TODO:
- Implement /gift <item> functionality
- Implement /gift energy functionality
- Implement gift success/failure mechanisms (to be able to refund the gift for various reasons)
- Support scientific (e.g. 1e3) and unit notations (1k) for quantity specification
- Add support for sending to a gift using id instead of username
- (Optional) Look how to get a list of connected users as a client (in order to validate the usernames before hand for the SendPacketToClient )