### PR TITLE
Combat - Initial setting and enemy units import

### DIFF
--- a/NebulaModel/Packets/Combat/SpaceSectorResponseDataPacket.cs
+++ b/NebulaModel/Packets/Combat/SpaceSectorResponseDataPacket.cs
@@ -1,0 +1,13 @@
+﻿namespace NebulaModel.Packets.Combat;
+
+public class SpaceSectorResponseDataPacket
+{
+    public SpaceSectorResponseDataPacket() { }
+
+    public SpaceSectorResponseDataPacket(byte[] spaceSectorResponseData)
+    {
+        SpaceSectorResponseData = spaceSectorResponseData;
+    }
+
+    public byte[] SpaceSectorResponseData { get; set; }
+}

--- a/NebulaModel/Packets/Session/HandshakeResponse.cs
+++ b/NebulaModel/Packets/Session/HandshakeResponse.cs
@@ -10,15 +10,17 @@ public class HandshakeResponse
 {
     public HandshakeResponse() { }
 
-    public HandshakeResponse(in GameDesc gameDesc, bool isNewPlayer, PlayerData localPlayerData, byte[] modsSettings,
+    public HandshakeResponse(in GameDesc gameDesc, byte[] combatSettingsData, bool isNewPlayer, PlayerData localPlayerData, byte[] modsSettings,
         int settingsCount, bool syncSoil, ushort numPlayers, string discordPartyId)
     {
         GalaxyAlgo = gameDesc.galaxyAlgo;
         GalaxySeed = gameDesc.galaxySeed;
         StarCount = gameDesc.starCount;
         ResourceMultiplier = gameDesc.resourceMultiplier;
+        IsPeaceMode = gameDesc.isPeaceMode;
         IsSandboxMode = gameDesc.isSandboxMode;
         SavedThemeIds = gameDesc.savedThemeIds;
+        CombatSettingsData = combatSettingsData;
         IsNewPlayer = isNewPlayer;
         LocalPlayerData = localPlayerData;
         ModsSettings = modsSettings;
@@ -32,8 +34,10 @@ public class HandshakeResponse
     public int GalaxySeed { get; set; }
     public int StarCount { get; set; }
     public float ResourceMultiplier { get; set; }
+    public bool IsPeaceMode { get; set; }
     public bool IsSandboxMode { get; set; }
     public int[] SavedThemeIds { get; set; }
+    public byte[] CombatSettingsData { get; set; }
     public bool IsNewPlayer { get; set; }
     public PlayerData LocalPlayerData { get; set; }
     public byte[] ModsSettings { get; set; }

--- a/NebulaModel/Packets/Session/LobbyResponse.cs
+++ b/NebulaModel/Packets/Session/LobbyResponse.cs
@@ -4,13 +4,15 @@ public class LobbyResponse
 {
     public LobbyResponse() { }
 
-    public LobbyResponse(in GameDesc gameDesc, byte[] modsSettings, int settingsCount, ushort numPlayers, string discordPartyId)
+    public LobbyResponse(in GameDesc gameDesc, byte[] combatSettingsData, byte[] modsSettings, int settingsCount, ushort numPlayers, string discordPartyId)
     {
         GalaxyAlgo = gameDesc.galaxyAlgo;
         GalaxySeed = gameDesc.galaxySeed;
         StarCount = gameDesc.starCount;
         ResourceMultiplier = gameDesc.resourceMultiplier;
+        IsPeaceMode = gameDesc.isPeaceMode;
         IsSandboxMode = gameDesc.isSandboxMode;
+        CombatSettingsData = combatSettingsData;
         SavedThemeIds = gameDesc.savedThemeIds;
         ModsSettings = modsSettings;
         ModsSettingsCount = settingsCount;
@@ -22,8 +24,10 @@ public class LobbyResponse
     public int GalaxySeed { get; set; }
     public int StarCount { get; set; }
     public float ResourceMultiplier { get; set; }
+    public bool IsPeaceMode { get; set; }
     public bool IsSandboxMode { get; set; }
     public int[] SavedThemeIds { get; set; }
+    public byte[] CombatSettingsData { get; set; }
     public byte[] ModsSettings { get; set; }
     public int ModsSettingsCount { get; set; }
     public ushort NumPlayers { get; set; }

--- a/NebulaNetwork/PacketProcessors/Combat/SpaceSectorResponseDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/SpaceSectorResponseDataProcessor.cs
@@ -1,0 +1,29 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat;
+
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Combat;
+
+[RegisterPacketProcessor]
+internal class SpaceSectorResponseDataProcessor : PacketProcessor<SpaceSectorResponseDataPacket>
+{
+    protected override void ProcessPacket(SpaceSectorResponseDataPacket packet, NebulaConnection conn)
+    {
+        if (IsHost)
+        {
+            return;
+        }
+
+        using (var reader = new BinaryUtils.Reader(packet.SpaceSectorResponseData))
+        {
+            GameMain.data.spaceSector.Import(reader.BinaryReader);
+        }
+        GameMain.mainPlayer.mecha.CheckCombatModuleDataIsValidPatch();
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Session/GlobalGameDataRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/GlobalGameDataRequestProcessor.cs
@@ -4,6 +4,7 @@ using NebulaAPI.Packets;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.GameHistory;
+using NebulaModel.Packets.Combat;
 using NebulaModel.Packets.Session;
 using NebulaModel.Packets.Statistics;
 using NebulaModel.Packets.Trash;
@@ -33,14 +34,23 @@ internal class GlobalGameDataRequestProcessor : PacketProcessor<GlobalGameDataRe
 
         using (var writer = new BinaryUtils.Writer())
         {
-            GameMain.data.trashSystem.Export(writer.BinaryWriter);
-            conn.SendPacket(new TrashSystemResponseDataPacket(writer.CloseAndGetBytes()));
+            // Initial syncing from vanilla, to be refined later in future.
+            GameMain.data.spaceSector.BeginSave();
+            GameMain.data.spaceSector.Export(writer.BinaryWriter);
+            GameMain.data.spaceSector.EndSave();
+            conn.SendPacket(new SpaceSectorResponseDataPacket(writer.CloseAndGetBytes()));
         }
 
         using (var writer = new BinaryUtils.Writer())
         {
             GameMain.data.milestoneSystem.Export(writer.BinaryWriter);
             conn.SendPacket(new MilestoneDataResponse(writer.CloseAndGetBytes()));
+        }
+
+        using (var writer = new BinaryUtils.Writer())
+        {
+            GameMain.data.trashSystem.Export(writer.BinaryWriter);
+            conn.SendPacket(new TrashSystemResponseDataPacket(writer.CloseAndGetBytes()));
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Session/HandshakeResponseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/HandshakeResponseProcessor.cs
@@ -44,8 +44,13 @@ public class HandshakeResponseProcessor : PacketProcessor<HandshakeResponse>
         // Using GameDesc.Import will break GS2, so use GameDesc.SetForNewGame instead
         var gameDesc = new GameDesc();
         gameDesc.SetForNewGame(packet.GalaxyAlgo, packet.GalaxySeed, packet.StarCount, 1, packet.ResourceMultiplier);
-        gameDesc.savedThemeIds = packet.SavedThemeIds;
+        gameDesc.isPeaceMode = packet.IsPeaceMode;
         gameDesc.isSandboxMode = packet.IsSandboxMode;
+        gameDesc.savedThemeIds = packet.SavedThemeIds;
+        using (var p = new BinaryUtils.Reader(packet.CombatSettingsData))
+        {
+            gameDesc.combatSettings.Import(p.BinaryReader);
+        }
         DSPGame.StartGameSkipPrologue(gameDesc);
 
         InGamePopup.ShowInfo("Loading".Translate(), "Loading state from server, please wait".Translate(), null);

--- a/NebulaNetwork/PacketProcessors/Session/LobbyResponseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/LobbyResponseProcessor.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System;
 using BepInEx.Bootstrap;
 using NebulaAPI.Interfaces;
 using NebulaAPI.Packets;
@@ -40,11 +41,17 @@ internal class LobbyResponseProcessor : PacketProcessor<LobbyResponse>
 
         var gameDesc = new GameDesc();
         gameDesc.SetForNewGame(packet.GalaxyAlgo, packet.GalaxySeed, packet.StarCount, 1, packet.ResourceMultiplier);
-        gameDesc.savedThemeIds = packet.SavedThemeIds;
+        gameDesc.isPeaceMode = packet.IsPeaceMode;
         gameDesc.isSandboxMode = packet.IsSandboxMode;
+        gameDesc.savedThemeIds = new int[packet.SavedThemeIds.Length];
+        Array.Copy(packet.SavedThemeIds, gameDesc.savedThemeIds, packet.SavedThemeIds.Length);
+        using (var p = new BinaryUtils.Reader(packet.CombatSettingsData))
+        {
+            gameDesc.combatSettings.Import(p.BinaryReader);
+        }
 
         UIRoot.instance.galaxySelect.gameDesc = gameDesc;
         UIRoot.instance.galaxySelect.SetStarmapGalaxy();
-        UIRoot.instance.galaxySelect.sandboxToggle.isOn = packet.IsSandboxMode;
+        UIRoot.instance.galaxySelect.sandboxToggle.isOn = gameDesc.isSandboxMode;
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/CombatStat_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CombatStat_Patch.cs
@@ -1,0 +1,24 @@
+﻿#region
+
+using HarmonyLib;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Dynamic;
+
+[HarmonyPatch(typeof(CombatStat))]
+internal class CombatStat_Patch
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(CombatStat.TickSkillLogic))]
+    public static void TickSkillLogic_Prefix(ref CombatStat __instance)
+    {
+        if (NebulaWorld.Combat.CombatManager.LockBuildHp)
+        {
+            if (__instance.objectType == 0)
+            {
+                __instance.hp = __instance.hpMax;
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -371,13 +371,15 @@ internal class GameData_Patch
                 {
                     continue;
                 }
-                if (__instance.localStar.planets[i].factory == null)
+                var planet = __instance.localStar.planets[i];
+                if (planet.factory == null)
                 {
                     continue;
                 }
-                __instance.localStar.planets[i].factory.Free();
-                __instance.localStar.planets[i].factory = null;
-                GameMain.data.factoryCount--;
+                planet.factory.Free();
+                planet.factory = null;
+                __instance.galaxy.astrosFactory[planet.id] = null; //Assigned by UpdateRuntimePose
+                __instance.factoryCount--;
             }
         }
         if (!Multiplayer.Session.IsInLobby)

--- a/NebulaPatcher/Patches/Transpilers/UIDeathPanel_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIDeathPanel_Transpiler.cs
@@ -1,0 +1,52 @@
+﻿#region
+
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Transpilers;
+
+[HarmonyPatch(typeof(UIDeathPanel))]
+internal class UIDeathPanel_Transpiler
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(UIDeathPanel._OnOpen))]
+    [HarmonyPatch(nameof(UIDeathPanel.UpdatePropertyGroup))]
+    [HarmonyPatch(nameof(UIDeathPanel.UpdateRespawnOptionsGroup))]
+    [HarmonyPatch(nameof(UIDeathPanel.CalculateRespawnOptionsGroup))]
+    [HarmonyPatch(nameof(UIDeathPanel.OnRedeployButtonClick))]
+    [HarmonyPatch(nameof(UIDeathPanel.OnReassembleButtonClick))]
+    public static IEnumerable<CodeInstruction> ToSandboxMode_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        try
+        {
+            // Set respawn cost free in multiplayer session
+            // from: GameMain.data.gameDesc.isSandboxMode
+            // to:   GameMain.data.gameDesc.isSandboxMode | Multiplayer.IsActive
+
+            var codeMatcher = new CodeMatcher(instructions)
+                .MatchForward(true, new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(GameDesc), nameof(GameDesc.isSandboxMode))))
+                .Repeat(
+                    matcher => matcher
+                        .Advance(1)
+                        .Insert(
+                            new CodeInstruction(OpCodes.Call,
+                                AccessTools.DeclaredPropertyGetter(typeof(Multiplayer), nameof(Multiplayer.IsActive))),
+                            new CodeInstruction(OpCodes.Or)
+                        )
+                );
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (Exception e)
+        {
+            Log.Warn("Transpiler UIDeathPanel fail!");
+            Log.Warn(e);
+            return instructions;
+        }
+    }
+}

--- a/NebulaWorld/Combat/CombatManager.cs
+++ b/NebulaWorld/Combat/CombatManager.cs
@@ -1,0 +1,26 @@
+﻿#region
+
+using System;
+using NebulaModel.DataStructures;
+
+#endregion
+
+namespace NebulaWorld.Combat;
+
+public class CombatManager : IDisposable
+{
+    public readonly ToggleSwitch IsIncomingRequest = new();
+
+    public static bool LockBuildHp { get; private set; }
+
+    public CombatManager()
+    {
+        LockBuildHp = true;
+    }
+
+    public void Dispose()
+    {
+        LockBuildHp = false;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -4,6 +4,7 @@ using System;
 using NebulaAPI.GameState;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
+using NebulaWorld.Combat;
 using NebulaWorld.Factory;
 using NebulaWorld.GameDataHistory;
 using NebulaWorld.GameStates;
@@ -38,6 +39,7 @@ public class MultiplayerSession : IDisposable, IMultiplayerSession
 
         LocalPlayer = new LocalPlayer();
         World = new SimulatedWorld();
+        Combat = new CombatManager();
         Factories = new FactoryManager();
         Storage = new StorageManager();
         PowerTowers = new PowerTowerManager();
@@ -60,6 +62,7 @@ public class MultiplayerSession : IDisposable, IMultiplayerSession
     }
 
     public SimulatedWorld World { get; set; }
+    public CombatManager Combat { get; set; }
     public StorageManager Storage { get; set; }
     public PowerTowerManager PowerTowers { get; set; }
     public BeltManager Belts { get; set; }
@@ -100,6 +103,9 @@ public class MultiplayerSession : IDisposable, IMultiplayerSession
 
         World?.Dispose();
         World = null;
+
+        Combat?.Dispose();
+        Combat = null;
 
         Factories?.Dispose();
         Factories = null;


### PR DESCRIPTION
Provide a solid ground for the initial battle syncing
- [x] Sync `GameDesc.combatSettings` in handshake
- [x] Initial enemy units import when client join
- [x] Set player respawn cost to free in multiplayer game
- [x] Set allay building to invincible because building kill and drone repairing isn't synced yet 