### PR TITLE
Bugfixes (Game version 0.10.29.22010)

### DIFF
--- a/NebulaModel/Packets/Combat/CombatStatFullHpPacket.cs
+++ b/NebulaModel/Packets/Combat/CombatStatFullHpPacket.cs
@@ -1,10 +1,10 @@
 ﻿namespace NebulaModel.Packets.Combat;
 
-public class CombatStatFullHptPacket
+public class CombatStatFullHpPacket
 {
-    public CombatStatFullHptPacket() { }
+    public CombatStatFullHpPacket() { }
 
-    public CombatStatFullHptPacket(int originAstroId, int objectType, int objectId)
+    public CombatStatFullHpPacket(int originAstroId, int objectType, int objectId)
     {
         OriginAstroId = originAstroId;
         ObjectType = objectType;

--- a/NebulaModel/Packets/Combat/CombatStatFullHptPacket.cs
+++ b/NebulaModel/Packets/Combat/CombatStatFullHptPacket.cs
@@ -1,0 +1,17 @@
+﻿namespace NebulaModel.Packets.Combat;
+
+public class CombatStatFullHptPacket
+{
+    public CombatStatFullHptPacket() { }
+
+    public CombatStatFullHptPacket(int originAstroId, int objectType, int objectId)
+    {
+        OriginAstroId = originAstroId;
+        ObjectType = objectType;
+        ObjectId = objectId;
+    }
+
+    public int OriginAstroId { get; set; }
+    public int ObjectType { get; set; }
+    public int ObjectId { get; set; }
+}

--- a/NebulaModel/Packets/Combat/DFRelay/DFRelayArriveBasePacket.cs
+++ b/NebulaModel/Packets/Combat/DFRelay/DFRelayArriveBasePacket.cs
@@ -9,9 +9,16 @@ public class DFRelayArriveBasePacket
         HiveAstroId = dFRelay.hiveAstroId;
         RelayId = dFRelay.id;
         HiveRtseed = dFRelay.hive.rtseed;
+
+        var factory = dFRelay.hive.galaxy.astrosFactory[dFRelay.targetAstroId];
+        if (factory != null)
+        {
+            NextGroundEnemyId = factory.enemyRecycleCursor > 0 ? factory.enemyRecycle[factory.enemyRecycleCursor - 1] : factory.enemyCursor;
+        }
     }
 
     public int HiveAstroId { get; set; }
     public int RelayId { get; set; }
     public int HiveRtseed { get; set; }
+    public int NextGroundEnemyId { get; set; }
 }

--- a/NebulaModel/Packets/Combat/DFRelay/DFRelayRealizePlanetBasePacket.cs
+++ b/NebulaModel/Packets/Combat/DFRelay/DFRelayRealizePlanetBasePacket.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using NebulaAPI.DataStructures;
+
+namespace NebulaModel.Packets.Combat.DFRelay;
+
+public class DFRelayRealizePlanetBasePacket
+{
+    public DFRelayRealizePlanetBasePacket() { }
+
+    public DFRelayRealizePlanetBasePacket(in DFRelayComponent dFRelay)
+    {
+        HiveAstroId = dFRelay.hiveAstroId;
+        RelayId = dFRelay.id;
+        RelayNeutralizedCounter = dFRelay.hive.relayNeutralizedCounter;
+        HiveSeed = dFRelay.hive.seed;
+        HiveRtseed = dFRelay.hive.rtseed;
+        TargetAstroId = dFRelay.targetAstroId;
+        TargetLPos = dFRelay.targetLPos.ToFloat3();
+        TargetYaw = dFRelay.targetYaw;
+        BaseTicks = dFRelay.baseTicks;
+
+        var factory = dFRelay.hive.galaxy.astrosFactory[dFRelay.targetAstroId];
+        if (factory != null)
+        {
+            EnemyCursor = factory.enemyCursor;
+            EnemyRecyle = new int[factory.enemyRecycleCursor];
+            Array.Copy(factory.enemyRecycle, EnemyRecyle, EnemyRecyle.Length);
+        }
+        else
+        {
+            EnemyCursor = -1;
+            EnemyRecyle = [];
+        }
+    }
+
+    public int HiveAstroId { get; set; }
+    public int RelayId { get; set; }
+    public int RelayNeutralizedCounter { get; set; }
+    public int HiveSeed { get; set; }
+    public int HiveRtseed { get; set; }
+    public int TargetAstroId { get; set; }
+    public Float3 TargetLPos { get; set; }
+    public float TargetYaw { get; set; }
+    public int BaseTicks { get; set; }
+    public int EnemyCursor { get; set; }
+    public int[] EnemyRecyle { get; set; }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/CombatStatFullHpProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/CombatStatFullHpProcessor.cs
@@ -1,0 +1,62 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Combat;
+
+[RegisterPacketProcessor]
+public class CombatStatFullHpProcessor : PacketProcessor<CombatStatFullHptPacket>
+{
+    protected override void ProcessPacket(CombatStatFullHptPacket packet, NebulaConnection conn)
+    {
+        var combatStatId = 0;
+        var starId = 0;
+        if (packet.OriginAstroId > 100 && packet.OriginAstroId <= 204899 && packet.OriginAstroId % 100 > 0)
+        {
+            var planetFactory = GameMain.spaceSector.skillSystem.astroFactories[packet.OriginAstroId];
+            if (planetFactory != null)
+            {
+                starId = packet.OriginAstroId / 100;
+
+                if (packet.ObjectType == 0 && packet.ObjectId < planetFactory.entityPool.Length)
+                {
+                    combatStatId = planetFactory.entityPool[packet.ObjectId].combatStatId;
+                    planetFactory.entityPool[packet.ObjectId].combatStatId = 0;
+                }
+            }
+        }
+
+        var skillSystem = GameMain.spaceSector.skillSystem;
+        if (combatStatId > 0 && combatStatId < skillSystem.combatStats.cursor)
+        {
+            ref var combatStatRef = ref skillSystem.combatStats.buffer[combatStatId];
+            if (combatStatRef.id == combatStatId)
+            {
+                if (IsHost && combatStatRef.warningId > 0)
+                {
+                    GameMain.data.warningSystem.RemoveWarningData(combatStatRef.warningId);
+                }
+                skillSystem.OnRemovingSkillTarget(combatStatRef.id, combatStatRef.originAstroId, ETargetType.CombatStat);
+                skillSystem.combatStats.Remove(combatStatRef.id);
+            }
+        }
+
+        if (IsHost)
+        {
+            if (starId > 0)
+            {
+                Multiplayer.Session.Server.SendPacketToStarExclude(packet, starId, conn);
+            }
+            else
+            {
+                Multiplayer.Session.Server.SendPacketExclude(packet, conn);
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/CombatStatFullHpProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/CombatStatFullHpProcessor.cs
@@ -11,9 +11,9 @@ using NebulaWorld;
 namespace NebulaNetwork.PacketProcessors.Combat;
 
 [RegisterPacketProcessor]
-public class CombatStatFullHpProcessor : PacketProcessor<CombatStatFullHptPacket>
+public class CombatStatFullHpProcessor : PacketProcessor<CombatStatFullHpPacket>
 {
-    protected override void ProcessPacket(CombatStatFullHptPacket packet, NebulaConnection conn)
+    protected override void ProcessPacket(CombatStatFullHpPacket packet, NebulaConnection conn)
     {
         var combatStatId = 0;
         var starId = 0;

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayArriveBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayArriveBaseProcessor.cs
@@ -6,6 +6,7 @@ using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Combat.DFRelay;
 using NebulaWorld;
+using NebulaWorld.Combat;
 
 #endregion
 
@@ -33,7 +34,16 @@ public class DFRelayArriveBaseProcessor : PacketProcessor<DFRelayArriveBasePacke
         {
             hiveSystem.rtseed = packet.HiveRtseed;
             dfrelayComponent.stage = 2;
-            dfrelayComponent.ArriveBase();
+            using (Multiplayer.Session.Combat.IsIncomingRequest.On())
+            {
+                var factory = dfrelayComponent.hive.galaxy.astrosFactory[dfrelayComponent.targetAstroId];
+                if (factory != null)
+                {
+                    // Prepare enemyId in CreateEnemyPlanetBase
+                    EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.NextGroundEnemyId);
+                }
+                dfrelayComponent.ArriveBase();
+            }
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayRealizePlanetBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayRealizePlanetBaseProcessor.cs
@@ -1,0 +1,48 @@
+﻿#region
+
+using NebulaAPI.DataStructures;
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat.DFRelay;
+using NebulaWorld;
+using NebulaWorld.Combat;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Combat.DFRelay;
+
+[RegisterPacketProcessor]
+public class DFRelayRealizePlanetBaseProcessor : PacketProcessor<DFRelayRealizePlanetBasePacket>
+{
+    protected override void ProcessPacket(DFRelayRealizePlanetBasePacket packet, NebulaConnection conn)
+    {
+        var hiveSystem = GameMain.spaceSector.GetHiveByAstroId(packet.HiveAstroId);
+        if (hiveSystem == null) return;
+
+        var dfrelayComponent = hiveSystem.relays.buffer[packet.RelayId];
+        if (dfrelayComponent?.id != packet.RelayId) return;
+
+        dfrelayComponent.hive.relayNeutralizedCounter = packet.RelayNeutralizedCounter;
+        dfrelayComponent.hive.seed = packet.HiveSeed;
+        dfrelayComponent.hive.rtseed = packet.HiveRtseed;
+        dfrelayComponent.targetAstroId = packet.TargetAstroId;
+        dfrelayComponent.targetLPos = packet.TargetLPos.ToVector3();
+        dfrelayComponent.targetYaw = packet.TargetYaw;
+        dfrelayComponent.baseTicks = packet.BaseTicks;
+
+        using (Multiplayer.Session.Enemies.IsIncomingRelayRequest.On())
+        {
+            using (Multiplayer.Session.Combat.IsIncomingRequest.On())
+            {
+                var factory = dfrelayComponent.hive.galaxy.astrosFactory[dfrelayComponent.targetAstroId];
+                if (factory != null && packet.EnemyCursor != -1)
+                {
+                    // Prepare enemyIds in CreateEnemyPlanetBase
+                    EnemyManager.SetPlanetFactoryRecycle(factory, packet.EnemyCursor, packet.EnemyRecyle);
+                }
+                dfrelayComponent.RealizePlanetBase(GameMain.spaceSector);
+            }
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Turret/TurretSuperNovaProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Turret/TurretSuperNovaProcessor.cs
@@ -73,7 +73,6 @@ internal class TurretSuperNovaProcessor : PacketProcessor<TurretSuperNovaPacket>
         {
             return;
         }
-        uiTurret.supernovaWait = packet.SetSuperNova;
         if (refTurret.inSupernova)
         {
             GameMain.gameScenario.NotifyOnSupernovaUITriggered();

--- a/NebulaNetwork/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/FactoryLoadRequestProcessor.cs
@@ -63,5 +63,19 @@ public class FactoryLoadRequestProcessor : PacketProcessor<FactoryLoadRequest>
             }
             enemyDFHiveSystem = enemyDFHiveSystem.nextSibling;
         }
+
+        // Set entities (building) on the planet to full health
+        // Note: Try to sync the current value in the future
+        var astroId = planet.astroId;
+        var combatStatCursor = spaceSector.skillSystem.combatStats.cursor;
+        var buffer = spaceSector.skillSystem.combatStats.buffer;
+        for (var id = 1; id < combatStatCursor; id++)
+        {
+            if (buffer[id].id == id && buffer[id].astroId == astroId && buffer[id].objectType == 0)
+            {
+                buffer[id].HandleFullHp(GameMain.data, spaceSector.skillSystem);
+            }
+        }
+
     }
 }

--- a/NebulaNetwork/PacketProcessors/Universe/DysonSphereStatusProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/DysonSphereStatusProcessor.cs
@@ -19,8 +19,10 @@ internal class DysonSphereStatusProcessor : PacketProcessor<DysonSphereStatusPac
         {
             return;
         }
+        // Replace some values set in DysonSphere.BeforeGameTick
         dysonSphere.grossRadius = packet.GrossRadius;
         dysonSphere.energyReqCurrentTick = packet.EnergyReqCurrentTick;
         dysonSphere.energyGenCurrentTick = packet.EnergyGenCurrentTick;
+        dysonSphere.energyGenOriginalCurrentTick = (long)(dysonSphere.energyGenCurrentTick / dysonSphere.energyDFHivesDebuffCoef);
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/CombatStat_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CombatStat_Patch.cs
@@ -38,7 +38,7 @@ internal class CombatStat_Patch
         // objectType 0:entity
         if (__instance.objectType == 0 && __instance.originAstroId > 100 && __instance.originAstroId <= 204899 && __instance.originAstroId % 100 > 0)
         {
-            var packet = new CombatStatFullHptPacket(__instance.originAstroId, __instance.objectType, __instance.objectId);
+            var packet = new CombatStatFullHpPacket(__instance.originAstroId, __instance.objectType, __instance.objectId);
             if (Multiplayer.Session.IsServer)
             {
                 var starId = __instance.originAstroId / 100;

--- a/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
@@ -23,6 +23,17 @@ internal class DFRelayComponent_Patch
     }
 
     [HarmonyPrefix]
+    [HarmonyPatch(nameof(DFRelayComponent.RealizePlanetBase))]
+    public static bool RealizePlanetBase_Prefix(DFRelayComponent __instance)
+    {
+        if (!Multiplayer.IsActive) return true;
+        if (Multiplayer.Session.IsClient) return Multiplayer.Session.Enemies.IsIncomingRelayRequest;
+
+        Multiplayer.Session.Network.SendPacket(new DFRelayRealizePlanetBasePacket(__instance));
+        return true;
+    }
+
+    [HarmonyPrefix]
     [HarmonyPatch(nameof(DFRelayComponent.ArriveBase))]
     public static bool ArriveBase_Prefix(DFRelayComponent __instance)
     {

--- a/NebulaPatcher/Patches/Dynamic/EnemyDFHiveSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/EnemyDFHiveSystem_Patch.cs
@@ -251,18 +251,7 @@ internal class EnemyDFHiveSystem_Patch
         if (dfrelayComponent?.id == enemy.dfRelayId)
         {
             __instance.relayNeutralizedCounter++;
-            if (dfrelayComponent.baseState == 1 && dfrelayComponent.stage == 2)
-            {
-                var planetData = __instance.sector.galaxy.PlanetById(dfrelayComponent.targetAstroId);
-                if (planetData != null)
-                {
-                    //Don't call GetOrCreateFactory in client. Only realize if the factory is already load from server
-                    if (planetData.factory != null)
-                    {
-                        dfrelayComponent.RealizePlanetBase(__instance.sector);
-                    }
-                }
-            }
+            // Client will wait for server to send RealizePlanetBase packet
         }
         return false;
     }

--- a/NebulaPatcher/Patches/Dynamic/UITurretWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UITurretWindow_Patch.cs
@@ -145,7 +145,6 @@ internal class UITurretWindow_Patch
         {
             // Client will wait for server to authorize
             Multiplayer.Session.Network.SendPacket(packet);
-            __instance.supernovaWait &= !turret.inSupernova;
             return false;
         }
         else

--- a/NebulaWorld/Combat/CombatManager.cs
+++ b/NebulaWorld/Combat/CombatManager.cs
@@ -247,6 +247,28 @@ public class CombatManager : IDisposable
                 buffer[id].projectileId = 0;
             }
         }
+
+        // Clear all combatStat to avoid collision or index out of range error (mimic CombatStat.HandleFullHp)
+        for (var i = 1; i < factory.entityCursor; i++)
+        {
+            factory.entityPool[i].combatStatId = 0;
+        }
+        for (var i = 1; i < factory.craftCursor; i++)
+        {
+            factory.craftPool[i].combatStatId = 0;
+        }
+        for (var i = 1; i < factory.vegeCursor; i++)
+        {
+            factory.vegePool[i].combatStatId = 0;
+        }
+        for (var i = 1; i < factory.enemyCursor; i++)
+        {
+            factory.enemyPool[i].combatStatId = 0;
+        }
+        for (var i = 1; i < factory.veinCursor; i++)
+        {
+            factory.veinPool[i].combatStatId = 0;
+        }
     }
 
     public void OnAstroFactoryUnload()


### PR DESCRIPTION
0.10.29.22010 Fixes:
- Fix error when activating super nova in the turret window
- Fix desync of dyson sphere when client joins the game

0.10.29.21950 Fixes:
- Fix "Power Intercepted by dark fog hive" doesn`t get synced to client
- Attempt to fix base enemyId doesn't sync when relay creating it in client
NRE in `EnemyDFGroundSystem.KeyTickLogic (System.Int64 time);(IL_0929)`
- Try to avoid index out of range exception of combatStatId when client move to a planet of another system.
IndexOutOfRangeException in `ConstructionSystem.DetermineLaunch `  
Those combat stat ids may exceed range because client can't receive combat events of other systems.