### PR TITLE
Construction drones range limit & command /playerdata

### DIFF
--- a/NebulaNetwork/SaveManager.cs
+++ b/NebulaNetwork/SaveManager.cs
@@ -125,7 +125,7 @@ public static class SaveManager
                 // Supported revision: 5~8
                 if (revision is < 5 or > REVISION)
                 {
-                    throw new Exception($"Unsupport version {revision}");
+                    throw new Exception($"Unsupported version {revision}");
                 }
             }
 
@@ -160,7 +160,7 @@ public static class SaveManager
         catch (Exception e)
         {
             playerSaves.Clear();
-            Log.WarnInform("Skipping server data due to following excpetion:\n" + e.Message);
+            Log.WarnInform("Skipping server data due to exception:\n" + e.Message);
             Log.Warn(e);
             return;
         }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -174,10 +174,7 @@ public class Server : IServer
 
     public void Start()
     {
-        if (loadSaveFile)
-        {
-            SaveManager.LoadServerData();
-        }
+        SaveManager.LoadServerData(loadSaveFile);
 
         foreach (var assembly in AssembliesUtils.GetNebulaAssemblies())
         {

--- a/NebulaPatcher/Patches/Dynamic/ConstructionModuleComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/ConstructionModuleComponent_Patch.cs
@@ -3,6 +3,7 @@
 using HarmonyLib;
 using NebulaModel.Packets.Players;
 using NebulaWorld;
+using NebulaWorld.Player;
 
 #endregion
 
@@ -24,5 +25,18 @@ internal class ConstructionModuleComponent_Patch
         var priority = player.mecha.constructionModule.dronePriority;
         var packet = new PlayerEjectMechaDronePacket(playerId, planetId, targetObjectId, next1ObjectId, next2ObjectId, next3ObjectId, priority);
         Multiplayer.Session.Network.SendPacketToLocalStar(packet);
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(ConstructionModuleComponent.InsertTmpBuildTarget))]
+    public static bool InsertTmpBuildTarget_Prefix(ConstructionModuleComponent __instance, int objectId, float value)
+    {
+        if (__instance.entityId != 0 || value < DroneManager.MinSqrDistance) return true; // BAB, or distance is very close
+        if (!Multiplayer.IsActive) return true;
+
+        // Only send out mecha drones if local player is the closest player to the target prebuild
+        if (GameMain.localPlanet == null) return true;
+        var sqrDistToOtherPlayer = Multiplayer.Session.Drones.GetClosestRemotePlayerSqrDistance(GameMain.localPlanet.factory.prebuildPool[objectId].pos);
+        return value <= sqrDistToOtherPlayer;
     }
 }

--- a/NebulaPatcher/Patches/Transpilers/ConstructionSystem_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/ConstructionSystem_Transpiler.cs
@@ -1,0 +1,63 @@
+﻿#region
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Factory;
+using NebulaWorld;
+using NebulaWorld.Player;
+using UnityEngine;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Transpilers;
+
+[HarmonyPatch(typeof(ConstructionSystem))]
+internal class ConstructionSystem_Transpiler
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(ConstructionSystem.AddBuildTargetToModules))]
+    public static IEnumerable<CodeInstruction> AddBuildTargetToModules_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        try
+        {
+            /*  Sync Prebuild.itemRequired changes by player, insert local method call after player.package.TakeTailItems
+                Replace: if (num8 <= num) { this.player.mecha.constructionModule.InsertBuildTarget ... }
+                With:    if (num8 <= num && IsClosestPlayer(ref pos)) { this.player.mecha.constructionModule.InsertBuildTarget ... }
+            */
+
+            var codeMatcher = new CodeMatcher(instructions)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Ldloc_S),
+                    new CodeMatch(OpCodes.Ldloc_0),
+                    new CodeMatch(OpCodes.Bgt_Un)
+                );
+            Log.Info(codeMatcher.IsValid);
+            var sqrDist = codeMatcher.InstructionAt(-2).operand;
+            var skipLabel = codeMatcher.Operand;
+            codeMatcher.Advance(1)
+                .Insert(
+                    new CodeInstruction(OpCodes.Ldloc_S, sqrDist),
+                    new CodeInstruction(OpCodes.Ldarg_2), //ref Vector3 pos
+                    new CodeInstruction(OpCodes.Call, AccessTools.Method(typeof(ConstructionSystem_Transpiler), nameof(IsClosestPlayer))),
+                    new CodeInstruction(OpCodes.Brfalse_S, skipLabel)
+                );
+
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (System.Exception e)
+        {
+            Log.Error("Transpiler ConstructionSystem.AddBuildTargetToModules failed.");
+            Log.Error(e);
+            return instructions;
+        }
+    }
+
+    static bool IsClosestPlayer(float sqrDist, ref Vector3 pos)
+    {
+        if (!Multiplayer.IsActive || sqrDist < DroneManager.MinSqrDistance) return true;
+        return sqrDist <= Multiplayer.Session.Drones.GetClosestRemotePlayerSqrDistance(pos);
+    }
+}

--- a/NebulaWorld/Chat/ChatCommandRegistry.cs
+++ b/NebulaWorld/Chat/ChatCommandRegistry.cs
@@ -27,6 +27,7 @@ public static class ChatCommandRegistry
         RegisterCommand("system", new SystemCommandHandler(), "s");
         RegisterCommand("reconnect", new ReconnectCommandHandler(), "r");
         RegisterCommand("server", new ServerCommandHandler());
+        RegisterCommand("playerdata", new PlayerDataCommandHandler());
     }
 
     private static void RegisterCommand(string commandName, IChatCommandHandler commandHandlerHandler, params string[] aliases)

--- a/NebulaWorld/Chat/Commands/PlayerDataCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/PlayerDataCommandHandler.cs
@@ -1,0 +1,167 @@
+﻿#region
+
+using NebulaWorld.MonoBehaviours.Local.Chat;
+using System.Collections.Generic;
+using NebulaAPI.GameState;
+using HarmonyLib;
+using NebulaModel.DataStructures.Chat;
+using System.IO;
+using NebulaModel;
+using NebulaModel.Logger;
+using NebulaAPI.DataStructures;
+using NebulaModel.Networking;
+using NebulaModel.Packets.Players;
+
+#endregion
+
+namespace NebulaWorld.Chat.Commands;
+
+public class PlayerDataCommandHandler : IChatCommandHandler
+{
+    public void Execute(ChatWindow window, string[] parameters)
+    {
+        if (parameters.Length < 1)
+        {
+            throw new ChatCommandUsageException("Not enough arguments!".Translate());
+        }
+
+        // Due to dependency order, get SaveManager.playerSaves by reflection
+        var saveManagerType = AccessTools.TypeByName("NebulaNetwork.SaveManager");
+        var playerSaves = (Dictionary<string, IPlayerData>)AccessTools.Field(saveManagerType, "playerSaves").GetValue(null);
+
+        switch (parameters[0])
+        {
+            case "list":
+                {
+                    var resp = $"Player count in .server file: {playerSaves.Count}\n";
+                    foreach (var pair in playerSaves)
+                    {
+                        resp += $"[{pair.Key.Substring(0, 5)}] {pair.Value.Username}";
+                    }
+                    window.SendLocalChatMessage(resp, ChatMessageType.CommandOutputMessage);
+                    break;
+                }
+            case "load" when parameters.Length < 2:
+                throw new ChatCommandUsageException("Need to specifiy hash string or name of a player!");
+            case "load":
+                {
+                    var input = parameters[1];
+                    foreach (var pair in playerSaves)
+                    {
+                        if (input == pair.Key.Substring(0, input.Length) || input == pair.Value.Username)
+                        {
+                            window.SendLocalChatMessage($"Load [{pair.Key.Substring(0, 5)}] {pair.Value.Username}", ChatMessageType.CommandOutputMessage);
+                            LoadPlayerData(pair.Value);
+                            return;
+                        }
+                    }
+                    break;
+                }
+            case "remove" when parameters.Length < 2:
+                throw new ChatCommandUsageException("Need to specifiy hash string or name of a player!");
+            case "remove":
+                {
+                    var input = parameters[1];
+                    var removeHash = "";
+                    foreach (var pair in playerSaves)
+                    {
+                        if (input == pair.Key.Substring(0, input.Length) || input == pair.Value.Username)
+                        {
+                            window.SendLocalChatMessage($"Remove [{pair.Key.Substring(0, 5)}] {pair.Value.Username}", ChatMessageType.CommandOutputMessage);
+                            removeHash = pair.Key;
+                            break;
+                        }
+                    }
+                    playerSaves.Remove(removeHash);
+                    break;
+                }
+        }
+    }
+
+    public string GetDescription()
+    {
+        return "Manage the stored multiplayer player data".Translate();
+    }
+
+    public string[] GetUsage()
+    {
+        return ["list", "load <hashString>", "remove <hashString>"];
+    }
+
+    static void LoadPlayerData(IPlayerData playerData)
+    {
+        Log.Info($"Teleporting to target planet {GameMain.localPlanet?.id ?? 0} => {playerData.LocalPlanetId}");
+        var actionSail = GameMain.mainPlayer.controller.actionSail;
+        if (playerData.LocalPlanetId > 0)
+        {
+            if (playerData.LocalPlanetId == GameMain.localPlanet?.id)
+            {
+                UIRoot.instance.uiGame.globemap.LocalPlanetTeleport(playerData.LocalPlanetPosition.ToVector3());
+            }
+            else
+            {
+                var destPlanet = GameMain.galaxy.PlanetById(playerData.LocalPlanetId);
+                actionSail.fastTravelTargetPlanet = destPlanet;
+                actionSail.fastTravelTargetLPos = playerData.LocalPlanetPosition.ToVector3();
+                actionSail.fastTravelTargetUPos = destPlanet.uPosition + (VectorLF3)(destPlanet.runtimeRotation * actionSail.fastTravelTargetLPos);
+                actionSail.StartFastTravelToUPosition(actionSail.fastTravelTargetUPos);
+            }
+        }
+        else
+        {
+            GameMain.mainPlayer.controller.actionSail.StartFastTravelToUPosition(playerData.UPosition.ToVectorLF3());
+        }
+
+        var mechaData = playerData.Mecha;
+        Log.Info("Loading player inventory...");
+        using (var ms = new MemoryStream())
+        {
+            var bw = new BinaryWriter(ms);
+            mechaData.Inventory.Export(bw);
+            mechaData.DeliveryPackage.Export(bw);
+            mechaData.WarpStorage.Export(bw);
+
+            ms.Seek(0, SeekOrigin.Begin);
+            var br = new BinaryReader(ms);
+            GameMain.mainPlayer.package.Import(br);
+            GameMain.mainPlayer.deliveryPackage.Import(br);
+            GameMain.mainPlayer.mecha.warpStorage.Import(br);
+        }
+        if (!Config.Options.SyncSoil)
+        {
+            GameMain.mainPlayer.sandCount = mechaData.SandCount;
+        }
+        GameMain.mainPlayer.mecha.coreEnergy = mechaData.CoreEnergy;
+        GameMain.mainPlayer.mecha.reactorEnergy = mechaData.ReactorEnergy;
+
+        if (playerData.Appearance != null)
+        {
+            Log.Info("Loading custom appearance...");
+            playerData.Appearance.CopyTo(GameMain.mainPlayer.mecha.appearance);
+            GameMain.mainPlayer.mechaArmorModel.RefreshAllPartObjects();
+            GameMain.mainPlayer.mechaArmorModel.RefreshAllBoneObjects();
+            GameMain.mainPlayer.mecha.appearance.NotifyAllEvents();
+
+            var editor = UIRoot.instance.uiMechaEditor;
+            editor.selection.ClearSelection();
+            editor.saveGroup._Close();
+            if (editor.mecha.diyAppearance == null)
+            {
+                editor.mecha.diyAppearance = new MechaAppearance();
+                editor.mecha.diyAppearance.Init();
+            }
+            GameMain.mainPlayer.mecha.appearance.CopyTo(editor.mecha.diyAppearance);
+            editor.mechaArmorModel.RefreshAllPartObjects();
+            editor.mechaArmorModel.RefreshAllBoneObjects();
+            editor.mecha.diyAppearance.NotifyAllEvents();
+            editor._left_content_height_max = 0f;
+            editor.SetLeftScrollTop();
+            editor.saveGroup._Open();
+
+            using var writer = new BinaryUtils.Writer();
+            GameMain.mainPlayer.mecha.appearance.Export(writer.BinaryWriter);
+            Multiplayer.Session.Network.SendPacket(new PlayerMechaArmor(Multiplayer.Session.LocalPlayer.Id,
+                writer.CloseAndGetBytes()));
+        }
+    }
+}


### PR DESCRIPTION
## Construction drones range limit
Make construction drones only launch if the local player is closer than other remote players, or within 15m.
So that the drones won't try to fly to far prebuild that will be built by other players first.

## SaveManager
Clear playerSaves from the previous session when server starts.  

Add new chat command `/playerdata`.
![playerdata](https://github.com/NebulaModTeam/nebula/assets/50672801/0d4e7f36-a0f3-4e4d-a421-5e56f0b37436)
- `/playerdata list`: list all stored player data in format [hash] playerName
- `/playerdata remove <hash>`: remove the target player data from SaveManager.
- `/playerdata load <hash>`: load the target player data to overwrite inventory and appearance of local player, then teleport to the stored location.

With this command, it can achieve the following goal for the host:
1. Reset player data so they can join as a new player if they choose the wrong planet to start in the lobby.
2. After transferring the save files, get the stored player data instead of the data from the previous host.
