### PR TITLE
Add CLI argument -newgame-cfg and changes to chat format

### DIFF
--- a/NebulaModel/MultiplayerOptions.cs
+++ b/NebulaModel/MultiplayerOptions.cs
@@ -132,7 +132,11 @@ public class MultiplayerOptions : ICloneable
     [DisplayName("Auto Open Chat")]
     [Category("Chat")]
     [Description("Auto open chat window when receiving message from other players")]
-    public bool AutoOpenChat { get; set; } = true;
+    public bool AutoOpenChat { get; set; } = false;
+
+    [DisplayName("Show Timestamp")]
+    [Category("Chat")]
+    public bool EnableTimestamp { get; set; } = true;
 
     [DisplayName("Show system warn message")]
     [Category("Chat")]

--- a/NebulaModel/Packets/Chat/PlayerDataCommandPacket.cs
+++ b/NebulaModel/Packets/Chat/PlayerDataCommandPacket.cs
@@ -1,0 +1,19 @@
+﻿using NebulaModel.DataStructures;
+
+namespace NebulaModel.Packets.Chat;
+
+public class PlayerDataCommandPacket
+{
+    public PlayerDataCommandPacket() { }
+
+    public PlayerDataCommandPacket(string command, string message, PlayerData playerData = null)
+    {
+        Command = command;
+        Message = message;
+        PlayerData = playerData;
+    }
+
+    public string Command { get; set; }
+    public string Message { get; set; }
+    public PlayerData PlayerData { get; set; }
+}

--- a/NebulaNetwork/PacketProcessors/Chat/NewChatMessageProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/NewChatMessageProcessor.cs
@@ -26,14 +26,11 @@ internal class NewChatMessageProcessor : PacketProcessor<NewChatMessagePacket>
 
         if (IsHost)
         {
-            var player = Players.Get(conn);
             Server.SendPacketExclude(packet, conn);
         }
 
         var sentAt = packet.SentAt == 0 ? DateTime.Now : DateTime.FromBinary(packet.SentAt);
-        ChatManager.Instance.SendChatMessage(
-            string.IsNullOrEmpty(packet.UserName)
-                ? $"[{sentAt:HH:mm}] {packet.MessageText}"
-                : $"[{sentAt:HH:mm}] [{packet.UserName}] : {packet.MessageText}", packet.MessageType);
+        ChatManager.Instance.SendChatMessage(ChatManager.FormatChatMessage(sentAt, packet.UserName, packet.MessageText),
+            packet.MessageType);
     }
 }

--- a/NebulaNetwork/PacketProcessors/Chat/PlyaerDataCommmandProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/PlyaerDataCommmandProcessor.cs
@@ -1,0 +1,62 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.DataStructures.Chat;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Chat;
+using NebulaWorld;
+using NebulaWorld.Chat.Commands;
+using NebulaWorld.MonoBehaviours.Local.Chat;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Chat;
+
+[RegisterPacketProcessor]
+internal class PlyaerDataCommmandProcessor : PacketProcessor<PlayerDataCommandPacket>
+{
+    protected override void ProcessPacket(PlayerDataCommandPacket packet, NebulaConnection conn)
+    {
+        if (IsHost)
+        {
+            packet.PlayerData = null;
+            var playerSaves = SaveManager.PlayerSaves;
+            switch (packet.Command)
+            {
+                case "list":
+                    packet.Message = PlayerDataCommandHandler.GetPlayerDataListString();
+                    break;
+
+                case "load":
+                    var input = packet.Message;
+                    packet.Message = "Unable to find the target player data!";
+                    foreach (var pair in playerSaves)
+                    {
+                        if (input == pair.Key.Substring(0, input.Length) || input == pair.Value.Username)
+                        {
+                            packet.Message = $"Load [{pair.Key.Substring(0, 5)}] {pair.Value.Username}";
+                            packet.PlayerData = (NebulaModel.DataStructures.PlayerData)pair.Value;
+                            break;
+                        }
+                    }
+                    break;
+
+                default:
+                    packet.Message = "Unknown command: " + packet.Command;
+                    break;
+            }
+            conn.SendPacket(packet);
+            return;
+        }
+
+        if (IsClient)
+        {
+            ChatManager.Instance.SendChatMessage(packet.Message, ChatMessageType.CommandOutputMessage);
+            if (packet.PlayerData != null)
+            {
+                PlayerDataCommandHandler.LoadPlayerData(packet.PlayerData);
+            }
+        }
+    }
+}

--- a/NebulaPatcher/NebulaPlugin.cs
+++ b/NebulaPatcher/NebulaPlugin.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Reflection;
 using BepInEx;
+using BepInEx.Configuration;
 using HarmonyLib;
 using NebulaAPI.Interfaces;
 using NebulaModel.Logger;
@@ -77,6 +78,18 @@ public class NebulaPlugin : BaseUnityPlugin, IMultiplayerMod
                         didLoad = true;
                     }
                 }
+            }
+
+            if (args[i] == "-newgame-cfg")
+            {
+                newgameArgExists = true;
+                var gameDesc = new GameDesc();
+                var random = new DotNet35Random((int)(DateTime.UtcNow.Ticks / 10000L));
+                gameDesc.SetForNewGame(UniverseGen.algoVersion, random.Next(100000000), 64, 1, 1f);
+                SetGameDescFromConfigFile(gameDesc);
+                Log.Info($">> Creating new game ({gameDesc.galaxySeed}, {gameDesc.starCount}, {gameDesc.resourceMultiplier:F1})");
+                GameStatesManager.NewGameDesc = gameDesc;
+                didLoad = true;
             }
 
             if (args[i] == "-load" && i + 1 < args.Length)
@@ -230,6 +243,56 @@ public class NebulaPlugin : BaseUnityPlugin, IMultiplayerMod
         {
             FPSController.SetFixUPS(command_ups);
         }
+    }
+
+    public static void SetGameDescFromConfigFile(GameDesc gameDesc)
+    {
+        var customFile = new ConfigFile(Path.Combine(Paths.ConfigPath, "nebulaGameDescSettings.cfg"), true);
+
+        var galaxySeed = customFile.Bind("Basic", "galaxySeed", -1,
+            "Cluster Seed. Negative value: Random or remain the same.").Value;
+        if (galaxySeed >= 0)
+        {
+            gameDesc.galaxySeed = galaxySeed;
+        }
+
+        var starCount = customFile.Bind("Basic", "starCount", -1,
+            "Number of Stars. Negative value: Default(64) or remain the same.").Value;
+        if (starCount >= 0)
+        {
+            gameDesc.starCount = starCount;
+        }
+
+        var resourceMultiplier = customFile.Bind("Basic", "resourceMultiplier", -1f,
+            "Resource Multiplier. Infinte = 100. Negative value: Default(1.0f) or remain the same.").Value;
+        if (resourceMultiplier >= 0f)
+        {
+            gameDesc.resourceMultiplier = resourceMultiplier;
+        }
+
+        gameDesc.isPeaceMode = customFile.Bind("General", "isPeaceMode", false,
+            "False: Enable enemy force (combat mode)").Value;
+        gameDesc.isSandboxMode = customFile.Bind("General", "isSandboxMode", false,
+            "True: Enable creative mode").Value;
+
+        gameDesc.combatSettings.aggressiveness = customFile.Bind("Combat", "aggressiveness", 1f,
+            new ConfigDescription("Aggressiveness (Dummy = -1, Rampage = 3)", new AcceptableValueList<float>(-1f, 0f, 0.5f, 1f, 2f, 3f))).Value;
+        gameDesc.combatSettings.initialLevel = customFile.Bind("Combat", "initialLevel", 0,
+            new ConfigDescription("Initial Level (Original range: 0 to 10)", new AcceptableValueRange<int>(0, 30))).Value;
+        gameDesc.combatSettings.initialGrowth = customFile.Bind("Combat", "initialGrowth", 1f,
+            "Initial Growth (Original range: 0 to 200%)").Value;
+        gameDesc.combatSettings.initialColonize = customFile.Bind("Combat", "initialColonize", 1f,
+            "Initial Occupation (Original range: 1% to 200%").Value;
+        gameDesc.combatSettings.maxDensity = customFile.Bind("Combat", "maxDensity", 1f,
+            "Max Density (Original range: 1 to 3)").Value;
+        gameDesc.combatSettings.growthSpeedFactor = customFile.Bind("Combat", "growthSpeedFactor", 1f,
+            "Growth Speed (Original range: 25% to 300%)").Value;
+        gameDesc.combatSettings.powerThreatFactor = customFile.Bind("Combat", "powerThreatFactor", 1f,
+            "Power Threat Factor (Original range: 1% to 1000%)").Value;
+        gameDesc.combatSettings.battleThreatFactor = customFile.Bind("Combat", "battleThreatFactor", 1f,
+            "Combat Threat Factor (Original range: 1% to 1000%)").Value;
+        gameDesc.combatSettings.battleExpFactor = customFile.Bind("Combat", "battleExpFactor", 1f,
+            "Combat XP Factor (Original range: 1% to 1000%)").Value;
     }
 
     private static async void ActivityManager_OnActivityJoin(string secret)

--- a/NebulaWorld/Chat/ChatCommandRegistry.cs
+++ b/NebulaWorld/Chat/ChatCommandRegistry.cs
@@ -28,6 +28,7 @@ public static class ChatCommandRegistry
         RegisterCommand("reconnect", new ReconnectCommandHandler(), "r");
         RegisterCommand("server", new ServerCommandHandler());
         RegisterCommand("playerdata", new PlayerDataCommandHandler());
+        RegisterCommand("dev", new DevCommandHandler());
     }
 
     private static void RegisterCommand(string commandName, IChatCommandHandler commandHandlerHandler, params string[] aliases)

--- a/NebulaWorld/Chat/Commands/DevCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/DevCommandHandler.cs
@@ -1,0 +1,57 @@
+﻿#region
+
+using NebulaWorld.MonoBehaviours.Local.Chat;
+using NebulaModel.DataStructures.Chat;
+using HarmonyLib;
+
+#endregion
+
+namespace NebulaWorld.Chat.Commands;
+
+public class DevCommandHandler : IChatCommandHandler
+{
+    public void Execute(ChatWindow window, string[] parameters)
+    {
+        if (parameters.Length < 1)
+        {
+            throw new ChatCommandUsageException("Not enough arguments!".Translate());
+        }
+
+        switch (parameters[0])
+        {
+            case "sandbox":
+                {
+                    GameMain.sandboxToolsEnabled = !GameMain.sandboxToolsEnabled;
+                    GameMain.data.gameDesc.isSandboxMode = GameMain.sandboxToolsEnabled;
+                    window.SendLocalChatMessage("SandboxTool enable: " + GameMain.sandboxToolsEnabled, ChatMessageType.CommandOutputMessage);
+                    return;
+                }
+            case "load-cfg":
+                {
+                    window.SendLocalChatMessage("Overwrite settings from nebulaGameDescSettings.cfg", ChatMessageType.CommandOutputMessage);
+                    AccessTools.Method(AccessTools.TypeByName("NebulaPatcher.NebulaPlugin"), "SetGameDescFromConfigFile").Invoke(null, [GameMain.data.gameDesc]);
+                    return;
+                }
+
+            case "self-destruct":
+                {
+                    GameMain.mainPlayer.Kill();
+                    return;
+                }
+
+            default:
+                window.SendLocalChatMessage("Unknown command: " + parameters[0], ChatMessageType.CommandOutputMessage);
+                return;
+        }
+    }
+
+    public string GetDescription()
+    {
+        return "Developer/Sandbox tool commands".Translate();
+    }
+
+    public string[] GetUsage()
+    {
+        return ["sandbox", "load-cfg", "self-destruct"];
+    }
+}

--- a/NebulaWorld/Chat/Commands/PlayerDataCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/PlayerDataCommandHandler.cs
@@ -26,8 +26,7 @@ public class PlayerDataCommandHandler : IChatCommandHandler
         }
 
         // Due to dependency order, get SaveManager.playerSaves by reflection
-        var saveManagerType = AccessTools.TypeByName("NebulaNetwork.SaveManager");
-        var playerSaves = (Dictionary<string, IPlayerData>)AccessTools.Field(saveManagerType, "playerSaves").GetValue(null);
+        var playerSaves = SaveManager.PlayerSaves;
 
         switch (parameters[0])
         {
@@ -72,7 +71,7 @@ public class PlayerDataCommandHandler : IChatCommandHandler
                             break;
                         }
                     }
-                    playerSaves.Remove(removeHash);
+                    SaveManager.TryRemove(removeHash);
                     break;
                 }
         }

--- a/NebulaWorld/Chat/Commands/WhisperCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/WhisperCommandHandler.cs
@@ -29,8 +29,8 @@ public class WhisperCommandHandler : IChatCommandHandler
         var recipientUserName = parameters[0];
         var fullMessageBody = string.Join(" ", parameters.Skip(1));
         // first echo what the player typed so they know something actually happened
-        ChatManager.Instance.SendChatMessage($"[{DateTime.Now:HH:mm}] [To: {recipientUserName}] : {fullMessageBody}",
-            ChatMessageType.PlayerMessage);
+        ChatManager.Instance.SendChatMessage(ChatManager.FormatChatMessage(DateTime.Now, $"[To {recipientUserName}]", fullMessageBody),
+            ChatMessageType.PlayerMessagePrivate);
 
         var packet = new ChatCommandWhisperPacket(senderUsername, recipientUserName, fullMessageBody);
 
@@ -64,7 +64,7 @@ public class WhisperCommandHandler : IChatCommandHandler
 
     public static void SendWhisperToLocalPlayer(string sender, string mesageBody)
     {
-        ChatManager.Instance.SendChatMessage($"[{DateTime.Now:HH:mm}] [{sender} whispered] : {mesageBody}",
+        ChatManager.Instance.SendChatMessage(ChatManager.FormatChatMessage(DateTime.Now, $"[From {sender}]", mesageBody),
             ChatMessageType.PlayerMessagePrivate);
     }
 }

--- a/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
+++ b/NebulaWorld/MonoBehaviours/Local/Chat/ChatWindow.cs
@@ -182,7 +182,7 @@ public class ChatWindow : MonoBehaviour
     private void BroadcastChatMessage(string message, ChatMessageType chatMessageType = ChatMessageType.PlayerMessage)
     {
         QueueOutgoingChatMessage(message, chatMessageType);
-        var formattedMessage = $"[{DateTime.Now:HH:mm}] [{UserName}] : {message}";
+        var formattedMessage = ChatManager.FormatChatMessage(DateTime.Now, UserName, message);
         SendLocalChatMessage(formattedMessage, chatMessageType);
     }
 

--- a/NebulaWorld/SaveManager.cs
+++ b/NebulaWorld/SaveManager.cs
@@ -8,11 +8,10 @@ using NebulaModel.DataStructures;
 using NebulaModel.Logger;
 using NebulaModel.Networking.Serialization;
 using NebulaModel.Utils;
-using NebulaWorld;
 
 #endregion
 
-namespace NebulaNetwork;
+namespace NebulaWorld;
 
 public static class SaveManager
 {
@@ -175,5 +174,10 @@ public static class SaveManager
 
         playerSaves.Add(clientCertHash, playerData);
         return true;
+    }
+
+    public static bool TryRemove(string clientCertHash)
+    {
+        return playerSaves.Remove(clientCertHash);
     }
 }


### PR DESCRIPTION

- Move SaveManager from namespace NebulaNetwork to NebulaWorld (https://github.com/NebulaModTeam/nebula/pull/666#discussion_r1536601429)  


- Client can now use chat command `/playerdata list` and `/playerdata load`  
- Add config Multiplayer - Chat - Show Timestamp to enable/disable timestamp before the chat message.  
- Change chat message format. Now it will show an underlined link to the player's name to navigate.  
- Show a welcome message when the player joins the multiplayer game for the first time.  
- Add dedicated server CLI argument `/newgame-cfg`, which will load the parameters from the config file `nebulaGameDescSettings.cfg`. The config file will only appear after the first time using the argument. By default, it will use the default vanilla game config settings. (#671 )
- Add command `/dev` containing the following commands:
`/dev sandbox`: Toggle the sandbox mode.  
`/dev load-cfg`: Overwrite GameMain.data.gameDesc with the parameters in `nebulaGameDescSettings.cfg`. It's similar to the mod AlterTheFog. Useful to change game difficulty.
`/dev self-destruct`: Kill the current mecha. Handy to test respawn related functions.

![underline_chat](https://github.com/NebulaModTeam/nebula/assets/50672801/68b396b2-07f2-4eda-b812-9afe6db368f5)

