### PR TITLE
Multiple Bugfix

### DIFF
--- a/NebulaModel/Packets/Combat/GroundEnemy/DFGRemoveBasePacket.cs
+++ b/NebulaModel/Packets/Combat/GroundEnemy/DFGRemoveBasePacket.cs
@@ -1,0 +1,15 @@
+﻿namespace NebulaModel.Packets.Combat.GroundEnemy;
+
+public class DFGRemoveBasePacket
+{
+    public DFGRemoveBasePacket() { }
+
+    public DFGRemoveBasePacket(int planetId, int baseId)
+    {
+        PlanetId = planetId;
+        BaseId = baseId;
+    }
+
+    public int PlanetId { get; set; }
+    public int BaseId { get; set; }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateBaseProcessor.cs
@@ -25,6 +25,7 @@ public class DFGActivateBaseProcessor : PacketProcessor<DFGActivateBasePacket>
 
         if (!packet.SetToSeekForm)
         {
+            if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
             var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
             if (dFBase == null) return;
             dFBase.activeTick = 3;

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateBaseProcessor.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using NebulaAPI.DataStructures;
 using NebulaAPI.Packets;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
@@ -27,6 +26,7 @@ public class DFGActivateBaseProcessor : PacketProcessor<DFGActivateBasePacket>
         if (!packet.SetToSeekForm)
         {
             var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
+            if (dFBase == null) return;
             dFBase.activeTick = 3;
             using (Multiplayer.Session.Combat.IsIncomingRequest.On())
             {

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateUnitProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateUnitProcessor.cs
@@ -23,6 +23,7 @@ public class DFGActivateUnitProcessor : PacketProcessor<DFGActivateUnitPacket>
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())
         {
             EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.EnemyId);
+            if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
             var dfBase = factory.enemySystem.bases.buffer[packet.BaseId];
             if (dfBase == null) return;
             var gameTick = GameMain.gameTick;

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateUnitProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGActivateUnitProcessor.cs
@@ -24,6 +24,7 @@ public class DFGActivateUnitProcessor : PacketProcessor<DFGActivateUnitPacket>
         {
             EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.EnemyId);
             var dfBase = factory.enemySystem.bases.buffer[packet.BaseId];
+            if (dfBase == null) return;
             var gameTick = GameMain.gameTick;
 
             // the value inside enemyFormation.units[portId] is not reliable, so just overwrite it

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGDeferredCreateEnemyProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGDeferredCreateEnemyProcessor.cs
@@ -23,6 +23,7 @@ public class DFGDeferredCreateEnemyProcessor : PacketProcessor<DFGDeferredCreate
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())
         {
             EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.EnemyId);
+            if (factory.enemySystem.bases.buffer[packet.BaseId] == null) return;
             var enemyId = factory.CreateEnemyFinal(packet.BaseId, packet.BuilderIndex);
 
 #if DEBUG

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGDeferredCreateEnemyProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGDeferredCreateEnemyProcessor.cs
@@ -23,6 +23,7 @@ public class DFGDeferredCreateEnemyProcessor : PacketProcessor<DFGDeferredCreate
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())
         {
             EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.EnemyId);
+            if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
             if (factory.enemySystem.bases.buffer[packet.BaseId] == null) return;
             var enemyId = factory.CreateEnemyFinal(packet.BaseId, packet.BuilderIndex);
 

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGFormationAddUnitProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGFormationAddUnitProcessor.cs
@@ -5,7 +5,6 @@ using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Combat.GroundEnemy;
 using NebulaWorld;
-using static UnityEngine.UI.CanvasScaler;
 
 #endregion
 
@@ -20,6 +19,7 @@ public class DFGFormationAddUnitProcessor : PacketProcessor<DFGFormationAddUnitP
         if (factory == null) return;
 
         var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
+        if (dFBase == null) return;
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())
         {
             // Set the next id in EnemyFormation

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGFormationAddUnitProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGFormationAddUnitProcessor.cs
@@ -18,6 +18,7 @@ public class DFGFormationAddUnitProcessor : PacketProcessor<DFGFormationAddUnitP
         var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
         if (factory == null) return;
 
+        if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
         var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
         if (dFBase == null) return;
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGLaunchAssaultProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGLaunchAssaultProcessor.cs
@@ -1,6 +1,5 @@
 ﻿#region
 
-using System;
 using NebulaAPI.DataStructures;
 using NebulaAPI.Packets;
 using NebulaModel.Networking;
@@ -32,6 +31,7 @@ public class DFGLaunchAssaultProcessor : PacketProcessor<DFGLaunchAssaultPacket>
             EnemyManager.SetPlanetFactoryRecycle(factory, packet.EnemyCursor, packet.EnemyRecyle);
 
             var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
+            if (dFBase == null) return;
             dFBase.turboTicks = 60;
             dFBase.turboRepress = 0;
             dFBase.evolve.threat = packet.EvolveThreat;

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGLaunchAssaultProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGLaunchAssaultProcessor.cs
@@ -30,6 +30,7 @@ public class DFGLaunchAssaultProcessor : PacketProcessor<DFGLaunchAssaultPacket>
             // Set enemyRecycle pool to make enemyId stay in sync
             EnemyManager.SetPlanetFactoryRecycle(factory, packet.EnemyCursor, packet.EnemyRecyle);
 
+            if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
             var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
             if (dFBase == null) return;
             dFBase.turboTicks = 60;

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGRemoveBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGRemoveBaseProcessor.cs
@@ -1,0 +1,27 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat.GroundEnemy;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Combat.GroundEnemy;
+
+[RegisterPacketProcessor]
+public class DFGRemoveBaseProcessor : PacketProcessor<DFGRemoveBasePacket>
+{
+    protected override void ProcessPacket(DFGRemoveBasePacket packet, NebulaConnection conn)
+    {
+        var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
+        if (IsHost || factory == null) return;
+
+        using (Multiplayer.Session.Combat.IsIncomingRequest.On())
+        {
+            // EnemyDFGroundSystem.bases.SetNull(id);
+            factory.enemySystem.RemoveDFGBaseComponent(packet.BaseId);
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGUpdateBaseStatusProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/GroundEnemy/DFGUpdateBaseStatusProcessor.cs
@@ -17,6 +17,7 @@ public class DFGUpdateBaseStatusProcessor : PacketProcessor<DFGUpdateBaseStatusP
         var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
         if (factory == null) return;
 
+        if (packet.BaseId >= factory.enemySystem.bases.capacity) return;
         var dFBase = factory.enemySystem.bases.buffer[packet.BaseId];
         if (dFBase == null) return;
         ref var evolveData = ref dFBase.evolve;

--- a/NebulaNetwork/PacketProcessors/Factory/BuildEntityRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/BuildEntityRequestProcessor.cs
@@ -56,8 +56,13 @@ public class BuildEntityRequestProcessor : PacketProcessor<BuildEntityRequest>
             }
             else
             {
-                // Remote planets, or the factory is not loaded yet
-                planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId, false, false);
+                Multiplayer.Session.Factories.AddPlanetTimer(packet.PlanetId);
+                // setting specifyPlanet here to avoid accessing a null object (see GPUInstancingManager activePlanet getter)
+                var pData = GameMain.gpuiManager.specifyPlanet;
+                GameMain.gpuiManager.specifyPlanet = GameMain.galaxy.PlanetById(packet.PlanetId);
+                // Flatten the terrain for remote planet build by other players
+                planet.factory.BuildFinally(GameMain.mainPlayer, packet.PrebuildId, true, true);
+                GameMain.gpuiManager.specifyPlanet = pData;
             }
 
             Multiplayer.Session.Factories.EventFactory = null;

--- a/NebulaNetwork/PacketProcessors/Players/PlayerSandCountProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Players/PlayerSandCountProcessor.cs
@@ -14,19 +14,17 @@ public class PlayerSandCountProcessor : PacketProcessor<PlayerSandCount>
 {
     protected override void ProcessPacket(PlayerSandCount packet, NebulaConnection conn)
     {
+        var player = GameMain.mainPlayer;
+        var originalSandCount = player.sandCount;
+
         if (IsHost)
         {
-            if (!packet.IsDelta)
-            {
-                // when receive update request, host UpdateSyncedSandCount and send to other players
-                GameMain.mainPlayer.SetSandCount(packet.SandCount);
-            }
+            // when receive update request, host UpdateSyncedSandCount and send to other players
+            player.SetSandCount(packet.IsDelta ? originalSandCount + packet.SandCount : packet.SandCount);
             return;
         }
 
         // taken from Player.SetSandCount()
-        var player = GameMain.mainPlayer;
-        var originalSandCount = player.sandCount;
         if (packet.IsDelta)
         {
             player.sandCount += packet.SandCount;

--- a/NebulaPatcher/Patches/Dynamic/EnemyDFGroundSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/EnemyDFGroundSystem_Patch.cs
@@ -138,6 +138,23 @@ internal class EnemyDFGroundSystem_Patch
     }
 
     [HarmonyPrefix]
+    [HarmonyPatch(nameof(EnemyDFGroundSystem.RemoveDFGBaseComponent))]
+    public static bool RemoveDFGBaseComponent_Prefix(EnemyDFGroundSystem __instance, int id)
+    {
+        if (!Multiplayer.IsActive) return true;
+
+        if (Multiplayer.Session.IsServer)
+        {
+            var packet = new DFGRemoveBasePacket(__instance.factory.planetId, id);
+            Multiplayer.Session.Network.SendPacketToStar(packet, __instance.factory.planet.star.id);
+            return true;
+        }
+
+        // Client should wait for server to approve the removal of base from the base buffer
+        return Multiplayer.Session.Combat.IsIncomingRequest;
+    }
+
+    [HarmonyPrefix]
     [HarmonyPatch(nameof(EnemyDFGroundSystem.GameTickLogic))]
     public static void GameTickLogic_Prefix(EnemyDFGroundSystem __instance, long gameTick)
     {

--- a/NebulaWorld/Combat/CombatManager.cs
+++ b/NebulaWorld/Combat/CombatManager.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using NebulaAPI.DataStructures;
 using NebulaModel.DataStructures;
+using NebulaModel.Logger;
 using NebulaModel.Packets.Combat.Mecha;
 using UnityEngine;
 #pragma warning disable IDE1006 // Naming Styles
@@ -269,6 +270,22 @@ public class CombatManager : IDisposable
         {
             factory.veinPool[i].combatStatId = 0;
         }
+
+        // Clear the combatStat pool
+        var astroId = factory.planet.id;
+        var count = 0;
+        var combatStats = GameMain.data.spaceSector.skillSystem.combatStats;
+        var combatStatCursor = combatStats.cursor;
+        var combatStatbuffer = combatStats.buffer;
+        for (var i = 1; i < combatStatCursor; i++)
+        {
+            if (combatStatbuffer[i].id == i && combatStatbuffer[i].astroId == astroId)
+            {
+                combatStats.Remove(i);
+                count++;
+            }
+        }
+        Log.Info($"CombatManager: Clear {count} combatStat on {astroId}");
     }
 
     public void OnAstroFactoryUnload()

--- a/NebulaWorld/Combat/CombatManager.cs
+++ b/NebulaWorld/Combat/CombatManager.cs
@@ -8,6 +8,7 @@ using NebulaModel.Logger;
 using NebulaModel.Packets.Combat.Mecha;
 using UnityEngine;
 #pragma warning disable IDE1006 // Naming Styles
+#pragma warning disable CA1822 // Mark members as static
 
 #endregion
 
@@ -279,7 +280,8 @@ public class CombatManager : IDisposable
         var combatStatbuffer = combatStats.buffer;
         for (var i = 1; i < combatStatCursor; i++)
         {
-            if (combatStatbuffer[i].id == i && combatStatbuffer[i].astroId == astroId)
+            ref var ptr = ref combatStatbuffer[i];
+            if (ptr.id == i && ptr.astroId == astroId)
             {
                 combatStats.Remove(i);
                 count++;

--- a/NebulaWorld/Logistics/ILSShipManager.cs
+++ b/NebulaWorld/Logistics/ILSShipManager.cs
@@ -29,7 +29,7 @@ public class ILSShipManager
         var planetA = GameMain.galaxy.PlanetById(packet.PlanetA);
         var planetB = GameMain.galaxy.PlanetById(packet.PlanetB);
 
-        if (planetA == null || planetB == null)
+        if (planetA == null || planetB == null || packet.ThisGId < 1)
         {
             return;
         }
@@ -96,7 +96,7 @@ public class ILSShipManager
      */
     public static void WorkShipBackToIdle(ILSWorkShipBackToIdle packet)
     {
-        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        if (packet.GId < 1)
         {
             return;
         }


### PR DESCRIPTION
- Fix NRE in client when updating ILS ships position
`NebulaPatcher.Patches.Dynamic.GameData_Patch.GameTick_Postfix (GameData __instance, System.Int64 time);(IL_0119)`
- Fix hp bar doesn't vanish after deleting the building in client when they first join
(https://discord.com/channels/823320768086671421/858330101556183050/1225799593149599771)
- Fix buildings placed by clients on a remote planet not flatten the groud
(https://discord.com/channels/823320768086671421/858330101556183050/1221929569288851546)
- Fix soil gain/used by clients doesn't show the correct amount when the sync soil option is on.
(https://discord.com/channels/823320768086671421/858330101556183050/1225765952931495996)
- Add null check to `factory.enemySystem.bases.buffer[packet.BaseId]` for related packet processors in case of base desync