### PR TITLE
Enable Log.Debug and cleanup

### DIFF
--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -1,7 +1,6 @@
 ﻿#region
 
 using System;
-using System.Diagnostics;
 using System.Text.RegularExpressions;
 using WebSocketSharp;
 
@@ -21,13 +20,11 @@ public static class Log
         Log.logger = logger;
     }
 
-    [Conditional("DEBUG")]
     public static void Debug(string message)
     {
         logger.LogDebug(message);
     }
 
-    [Conditional("DEBUG")]
     public static void Debug(object message)
     {
         Debug(message?.ToString());
@@ -93,10 +90,10 @@ public static class Log
     public static void SocketOutput(LogData data, string _)
     {
         var log = data.ToString();
-        const string ipv4Regex = @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}";
-        const string ipv6Regex = "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}";
-        log = Regex.Replace(log, ipv4Regex, "(IPv4 Address)");
-        log = Regex.Replace(log, ipv6Regex, "(IPv6 Address)");
+        const string Ipv4Regex = @"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}";
+        const string Ipv6Regex = "([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}";
+        log = Regex.Replace(log, Ipv4Regex, "(IPv4 Address)");
+        log = Regex.Replace(log, Ipv6Regex, "(IPv6 Address)");
 
         if (data.Level >= LogLevel.Warn)
         {

--- a/NebulaModel/Packets/Combat/DFRelay/DFRelayArriveBasePacket.cs
+++ b/NebulaModel/Packets/Combat/DFRelay/DFRelayArriveBasePacket.cs
@@ -14,6 +14,7 @@ public class DFRelayArriveBasePacket
         if (factory != null)
         {
             NextGroundEnemyId = factory.enemyRecycleCursor > 0 ? factory.enemyRecycle[factory.enemyRecycleCursor - 1] : factory.enemyCursor;
+            HasFactory = factory.entityCount > 0;
         }
     }
 
@@ -21,4 +22,5 @@ public class DFRelayArriveBasePacket
     public int RelayId { get; set; }
     public int HiveRtseed { get; set; }
     public int NextGroundEnemyId { get; set; }
+    public bool HasFactory { get; set; }
 }

--- a/NebulaNetwork/PacketProcessors/Chat/PlayerDataCommmandProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/PlayerDataCommmandProcessor.cs
@@ -14,7 +14,7 @@ using NebulaWorld.MonoBehaviours.Local.Chat;
 namespace NebulaNetwork.PacketProcessors.Chat;
 
 [RegisterPacketProcessor]
-internal class PlyaerDataCommmandProcessor : PacketProcessor<PlayerDataCommandPacket>
+internal class PlayerDataCommmandProcessor : PacketProcessor<PlayerDataCommandPacket>
 {
     protected override void ProcessPacket(PlayerDataCommandPacket packet, NebulaConnection conn)
     {

--- a/NebulaNetwork/PacketProcessors/Chat/RemoteServerCommandProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Chat/RemoteServerCommandProcessor.cs
@@ -21,7 +21,7 @@ using NebulaWorld.GameStates;
 namespace NebulaNetwork.PacketProcessors.Chat;
 
 [RegisterPacketProcessor]
-internal class RemoteServerCommmandProcessor : PacketProcessor<RemoteServerCommandPacket>
+internal class RemoteServerCommandProcessor : PacketProcessor<RemoteServerCommandPacket>
 {
     private const int SERVERSAVE_COOLDOWN = 60;
     private const int SERVERLOGIN_COOLDOWN = 2;

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayArriveBaseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayArriveBaseProcessor.cs
@@ -43,6 +43,12 @@ public class DFRelayArriveBaseProcessor : PacketProcessor<DFRelayArriveBasePacke
                     EnemyManager.SetPlanetFactoryNextEnemyId(factory, packet.NextGroundEnemyId);
                 }
                 dfrelayComponent.ArriveBase();
+
+                // Display message when DF relay is successfully landed and the planet has buildings
+                if (packet.HasFactory && dfrelayComponent.baseId > 0)
+                {
+                    Multiplayer.Session.Enemies.DisplayPlanetPingMessage("DF relay landed on planet".Translate(), dfrelayComponent.targetAstroId, dfrelayComponent.targetLPos);
+                }
             }
         }
     }

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltReverseProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltReverseProcessor.cs
@@ -43,7 +43,7 @@ internal class BeltReverseProcessor : BasePacketProcessor<BeltReverseRequestPack
             var beltWindow = UIRoot.instance.uiGame.beltWindow;
             try
             {
-                beltWindow._Close(); // close the window first to avoid changing unwant variable when setting beltId
+                beltWindow._Close(); // close the window first to avoid changing unrelated variables when setting beltId
                 beltWindow.factory = factory;
                 beltWindow.traffic = factory.cargoTraffic;
                 beltWindow.player = GameMain.mainPlayer;

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltUpdatePickupItemsProcessor.cs
@@ -29,7 +29,7 @@ internal class BeltUpdatePickupItemsProcessor : PacketProcessor<BeltUpdatePickup
             }
             var beltComponent = traffic.beltPool[t.BeltId];
             var cargoPath = traffic.GetCargoPath(beltComponent.segPathId);
-            var ItemId = t.ItemId;
+            var itemId = t.ItemId;
             //Check if belt exists
             if (cargoPath == null)
             {
@@ -40,7 +40,7 @@ internal class BeltUpdatePickupItemsProcessor : PacketProcessor<BeltUpdatePickup
                  k <= beltComponent.segIndex + beltComponent.segLength - 1;
                  k++)
             {
-                if (cargoPath.TryPickItem(k - 4 - 1, 12, ItemId, out _, out _) != 0)
+                if (cargoPath.TryPickItem(k - 4 - 1, 12, itemId, out _, out _) != 0)
                 {
                     return;
                 }
@@ -48,13 +48,13 @@ internal class BeltUpdatePickupItemsProcessor : PacketProcessor<BeltUpdatePickup
             // Search upstream for target item
             for (var k = beltComponent.segIndex + beltComponent.segPivotOffset - 1; k >= beltComponent.segIndex; k--)
             {
-                if (cargoPath.TryPickItem(k - 4 - 1, 12, ItemId, out _, out _) != 0)
+                if (cargoPath.TryPickItem(k - 4 - 1, 12, itemId, out _, out _) != 0)
                 {
                     return;
                 }
             }
             Log.Warn(
-                $"BeltUpdatePickupItem: Cannot pick item{ItemId} on belt{t.BeltId}, planet{packet.PlanetId}");
+                $"BeltUpdatePickupItem: Cannot pick item{itemId} on belt{t.BeltId}, planet{packet.PlanetId}");
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Monitor/MonitorSettingUpdateProcessor.cs
@@ -70,7 +70,7 @@ internal class MonitorSettingUpdateProcessor : PacketProcessor<MonitorSettingUpd
                         break;
 
                     default:
-                        Log.Warn($"MonitorSettingUpdatePacket: Unkown MonitorSettingEvent {packet.Event}");
+                        Log.Warn($"MonitorSettingUpdatePacket: Unknown MonitorSettingEvent {packet.Event}");
                         break;
                 }
 

--- a/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/PowerTower/PowerTowerChargerUpdateProcessor.cs
@@ -44,7 +44,7 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
             {
                 Multiplayer.Session.PowerTowers.RemoteChargerHashIds.Add(hashId, 1);
             }
-            NebulaModel.Logger.Log.Debug($"Add remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId]}");
+            // Add remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId]}
         }
         else
         {
@@ -52,7 +52,7 @@ internal class PowerTowerChargerUpdateProcessor : PacketProcessor<PowerTowerChar
             {
                 return;
             }
-            NebulaModel.Logger.Log.Debug($"Remove remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] - 1}");
+            // Remove remote charger [{packet.PlanetId}-{packet.NodeId}]: {Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] - 1}
             Multiplayer.Session.PowerTowers.RemoteChargerHashIds[hashId] = playerCount - 1;
             if (playerCount <= 1)
             {

--- a/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryEnqueueTechProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryEnqueueTechProcessor.cs
@@ -14,19 +14,10 @@ namespace NebulaNetwork.PacketProcessors.GameHistory;
 [RegisterPacketProcessor]
 internal class GameHistoryEnqueueTechProcessor : PacketProcessor<GameHistoryEnqueueTechPacket>
 {
-    public GameHistoryEnqueueTechProcessor()
-    {
-    }
-
     protected override void ProcessPacket(GameHistoryEnqueueTechPacket packet, NebulaConnection conn)
     {
         if (IsHost)
         {
-            var player = Players.Get(conn);
-            if (player == null)
-            {
-                return;
-            }
             using (Multiplayer.Session.History.IsIncomingRequest.On())
             {
                 GameMain.history.EnqueueTech(packet.TechId);

--- a/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryRemoveTechProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameHistory/GameHistoryRemoveTechProcessor.cs
@@ -16,29 +16,11 @@ namespace NebulaNetwork.PacketProcessors.GameHistory;
 [RegisterPacketProcessor]
 internal class GameHistoryRemoveTechProcessor : PacketProcessor<GameHistoryRemoveTechPacket>
 {
-    public GameHistoryRemoveTechProcessor()
-    {
-    }
-
     protected override void ProcessPacket(GameHistoryRemoveTechPacket packet, NebulaConnection conn)
     {
-        var valid = true;
         if (IsHost)
         {
-            var player = Players.Get(conn);
-            if (player != null)
-            {
-                Server.SendPacketExclude(packet, conn);
-            }
-            else
-            {
-                valid = false;
-            }
-        }
-
-        if (!valid)
-        {
-            return;
+            Server.SendPacketExclude(packet, conn);
         }
         using (Multiplayer.Session.History.IsIncomingRequest.On())
         {

--- a/NebulaNetwork/PacketProcessors/GameStates/GameStateSaveInfoProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameStates/GameStateSaveInfoProcessor.cs
@@ -1,9 +1,12 @@
 ﻿#region
 
+using System;
 using NebulaAPI.Packets;
+using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.GameStates;
+using NebulaWorld;
 using NebulaWorld.GameStates;
 
 #endregion
@@ -16,5 +19,6 @@ public class GameStateSaveInfoProcessor : PacketProcessor<GameStateSaveInfoPacke
     protected override void ProcessPacket(GameStateSaveInfoPacket packet, NebulaConnection conn)
     {
         GameStatesManager.LastSaveTime = packet.LastSaveTime;
+        Log.Info("LastSaveTime: " + DateTimeOffset.FromUnixTimeSeconds(packet.LastSaveTime).ToString());
     }
 }

--- a/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/GameStates/GameStateUpdateProcessor.cs
@@ -21,7 +21,7 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
 {
     private readonly float BUFFERING_TICK = 60f;
     private readonly float BUFFERING_TIME = 30f;
-    private float avaerageUPS = 60f;
+    private float averageUPS = 60f;
 
     private int averageRTT;
     private bool hasChanged;
@@ -30,7 +30,7 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
     {
         var rtt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - packet.SentTime;
         averageRTT = (int)(averageRTT * 0.8 + rtt * 0.2);
-        avaerageUPS = avaerageUPS * 0.8f + packet.UnitsPerSecond * 0.2f;
+        averageUPS = averageUPS * 0.8f + packet.UnitsPerSecond * 0.2f;
         Multiplayer.Session.World.UpdatePingIndicator($"Ping: {averageRTT}ms");
 
         // We offset the tick received to account for the time it took to receive the packet
@@ -39,7 +39,7 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
         var diff = currentGameTick - GameMain.gameTick;
 
         // Discard abnormal packet (usually after host saving the file)
-        if (rtt > 2 * averageRTT || avaerageUPS - packet.UnitsPerSecond > 15)
+        if (rtt > 2 * averageRTT || averageUPS - packet.UnitsPerSecond > 15)
         {
             // Initial connection
             if (GameMain.gameTick < 1200L)
@@ -48,7 +48,7 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
                 GameMain.gameTick = currentGameTick;
             }
             Log.Debug(
-                $"GameStateUpdate unstable. RTT:{rtt}(avg{averageRTT}) UPS:{packet.UnitsPerSecond:F2}(avg{avaerageUPS:F2})");
+                $"GameStateUpdate unstable. RTT:{rtt}(avg{averageRTT}) UPS:{packet.UnitsPerSecond:F2}(avg{averageUPS:F2})");
             return;
         }
 
@@ -57,7 +57,7 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
             // We allow for a small drift of 5 ticks since the tick offset using the ping is only an approximation
             if (GameMain.gameTick > 0 && Mathf.Abs(diff) > 5)
             {
-                Log.Info($"Game Tick got updated since it was desynced, was {GameMain.gameTick}, diff={diff}");
+                Log.Debug($"Game Tick desync. {GameMain.gameTick} skip={diff} UPS:{packet.UnitsPerSecond:F2}(avg{averageUPS:F2})");
                 GameMain.gameTick = currentGameTick;
             }
             // Reset FixUPS when user turns off the option
@@ -71,39 +71,39 @@ public class GameStateUpdateProcessor : PacketProcessor<GameStateUpdate>
         }
 
         // Adjust client's UPS to match game tick with server, range 30~120 UPS
-        var UPS = diff / 1f + avaerageUPS;
+        var ups = diff / 1f + averageUPS;
         long skipTick = 0;
-        switch (UPS)
+        switch (ups)
         {
             case > GameStatesManager.MaxUPS:
                 {
-                    // Try to disturbute game tick difference into BUFFERING_TIME (seconds)
-                    if (diff / BUFFERING_TIME + avaerageUPS > GameStatesManager.MaxUPS)
+                    // Try to distribute game tick difference into BUFFERING_TIME (seconds)
+                    if (diff / BUFFERING_TIME + averageUPS > GameStatesManager.MaxUPS)
                     {
                         // The difference is too large, need to skip ticks to catch up
-                        skipTick = (long)(UPS - GameStatesManager.MaxUPS);
+                        skipTick = (long)(ups - GameStatesManager.MaxUPS);
                     }
-                    UPS = GameStatesManager.MaxUPS;
+                    ups = GameStatesManager.MaxUPS;
                     break;
                 }
             case < GameStatesManager.MinUPS:
                 {
-                    if (diff + avaerageUPS - GameStatesManager.MinUPS < -BUFFERING_TICK)
+                    if (diff + averageUPS - GameStatesManager.MinUPS < -BUFFERING_TICK)
                     {
-                        skipTick = (long)(UPS - GameStatesManager.MinUPS);
+                        skipTick = (long)(ups - GameStatesManager.MinUPS);
                     }
-                    UPS = GameStatesManager.MinUPS;
+                    ups = GameStatesManager.MinUPS;
                     break;
                 }
         }
         if (skipTick != 0)
         {
-            Log.Info($"Game Tick was desynced. skip={skipTick} diff={diff,2}, RTT={rtt}ms, UPS={packet.UnitsPerSecond:F2}");
+            Log.Debug($"Game Tick desync. skip={skipTick} diff={diff,2}, RTT={rtt}ms, UPS={packet.UnitsPerSecond:F2}(avg{averageUPS:F2})");
             GameMain.gameTick += skipTick;
         }
-        FPSController.SetFixUPS(UPS);
+        FPSController.SetFixUPS(ups);
         hasChanged = true;
         // Tick difference in the next second. Expose for other mods
-        GameStatesManager.NotifyTickDifference(diff / 1f + avaerageUPS - UPS);
+        GameStatesManager.NotifyTickDifference(diff / 1f + averageUPS - ups);
     }
 }

--- a/NebulaNetwork/PacketProcessors/Logistics/ILSAddStationComponentProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/ILSAddStationComponentProcessor.cs
@@ -29,7 +29,7 @@ public class ILSAddStationComponentProcessor : PacketProcessor<ILSAddStationComp
             {
                 // If we have loaded the factory where the new station was created on, should be able to find
                 // it in our PlanetTransport.stationPool
-                // Assgin gid here so this station will go to galacticTransport.stationPool[gid]
+                // Assign gid here so this station will go to galacticTransport.stationPool[gid]
                 stationPool[packet.StationId].gid = packet.StationGId;
                 if (galacticTransport.AddStationComponent(packet.PlanetId, stationPool[packet.StationId]) != packet.StationGId)
                 {

--- a/NebulaNetwork/PacketProcessors/Logistics/ILSArriveStarPlanetRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/ILSArriveStarPlanetRequestProcessor.cs
@@ -14,7 +14,7 @@ using NebulaWorld;
 
 /*
  * when a client arrives at a star he needs to sync the ILS storages as update events are sent only to corresponding stars
- * and also to sync the belt filters conencted to the ILS
+ * and also to sync the belt filters connected to the ILS
  */
 namespace NebulaNetwork.PacketProcessors.Logistics;
 
@@ -28,11 +28,6 @@ internal class ILSArriveStarPlanetRequestProcessor : PacketProcessor<ILSArriveSt
             return;
         }
 
-        var player = Players.Get(conn, EConnectionStatus.Connected) ?? Players.Get(conn, EConnectionStatus.Syncing);
-        if (player == null)
-        {
-            return;
-        }
         var stationGId = new List<int>();
         var stationPId = new List<int>();
         var stationMaxShips = new List<int>();
@@ -91,7 +86,7 @@ internal class ILSArriveStarPlanetRequestProcessor : PacketProcessor<ILSArriveSt
             offsetStorage += storageLength[i];
         }
 
-        player.SendPacket(new ILSArriveStarPlanetResponse(stationGId.ToArray(),
+        conn.SendPacket(new ILSArriveStarPlanetResponse(stationGId.ToArray(),
             stationPId.ToArray(),
             stationMaxShips.ToArray(),
             storageLength.ToArray(),

--- a/NebulaNetwork/PacketProcessors/Logistics/ILSUpdateRouteProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/ILSUpdateRouteProcessor.cs
@@ -1,7 +1,6 @@
 ﻿#region
 
 using NebulaAPI.Packets;
-using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Logistics;
@@ -16,7 +15,6 @@ public class ILSUpdateRouteProcessor : PacketProcessor<ILSUpdateRoute>
 {
     protected override void ProcessPacket(ILSUpdateRoute packet, NebulaConnection conn)
     {
-        Log.Debug($"{packet.Type} id0:{packet.Id0} id1:{packet.Id1}");
         using (Multiplayer.Session.Ships.PatchLockILS.On())
         {
             var galacticTransport = GameMain.data.galacticTransport;

--- a/NebulaNetwork/PacketProcessors/Logistics/ILSgStationPoolSyncRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/ILSgStationPoolSyncRequestProcessor.cs
@@ -29,11 +29,6 @@ public class ILSgStationPoolSyncRequestProcessor : PacketProcessor<ILSRequestgSt
             return;
         }
 
-        var player = Players.Get(conn, EConnectionStatus.Connected) ?? Players.Get(conn, EConnectionStatus.Syncing);
-        if (player == null)
-        {
-            return;
-        }
         var iter = 0;
 
         var countILS = GameMain.data.galacticTransport.stationPool.Count(stationComponent => stationComponent != null);
@@ -147,6 +142,6 @@ public class ILSgStationPoolSyncRequestProcessor : PacketProcessor<ILSRequestgSt
             shipAngularVel.ToArray(),
             shipPPosTemp.ToArray(),
             shipPRotTemp.ToArray());
-        player.SendPacket(packet2);
+        conn.SendPacket(packet2);
     }
 }

--- a/NebulaNetwork/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Planet/PlanetDataRequestProcessor.cs
@@ -59,7 +59,7 @@ public class PlanetDataRequestProcessor : PacketProcessor<PlanetDataRequest>
             planetAlgorithm.GenerateTerrain(planet.mod_x, planet.mod_y);
             planetAlgorithm.CalcWaterPercent();
 
-            //Load planet meshes and register callback to unload unneccessary stuff
+            // Load planet meshes and register callback to unload unnecessary stuff
             planet.wanted = true;
             planet.onLoaded += OnActivePlanetLoaded;
             PlanetModelingManager.modPlanetReqList.Enqueue(planet);

--- a/NebulaNetwork/PacketProcessors/Players/PlayerMechaDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Players/PlayerMechaDataProcessor.cs
@@ -15,10 +15,6 @@ namespace NebulaNetwork.PacketProcessors.Players;
 [RegisterPacketProcessor]
 internal class PlayerMechaDataProcessor : PacketProcessor<PlayerMechaData>
 {
-    public PlayerMechaDataProcessor()
-    {
-    }
-
     protected override void ProcessPacket(PlayerMechaData packet, NebulaConnection conn)
     {
         if (IsClient)

--- a/NebulaNetwork/PacketProcessors/Players/PlayerMovementProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Players/PlayerMovementProcessor.cs
@@ -14,10 +14,6 @@ namespace NebulaNetwork.PacketProcessors.Players;
 [RegisterPacketProcessor]
 public class PlayerMovementProcessor : PacketProcessor<PlayerMovement>
 {
-    public PlayerMovementProcessor()
-    {
-    }
-
     protected override void ProcessPacket(PlayerMovement packet, NebulaConnection conn)
     {
         var valid = true;

--- a/NebulaNetwork/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Routers/PlanetBroadcastProcessor.cs
@@ -13,10 +13,6 @@ namespace NebulaNetwork.PacketProcessors.Routers;
 [RegisterPacketProcessor]
 internal class PlanetBroadcastProcessor : PacketProcessor<PlanetBroadcastPacket>
 {
-    public PlanetBroadcastProcessor()
-    {
-    }
-
     protected override void ProcessPacket(PlanetBroadcastPacket packet, NebulaConnection conn)
     {
         //Forward packet to other users if we're the host

--- a/NebulaNetwork/PacketProcessors/Routers/StarBroadcastProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Routers/StarBroadcastProcessor.cs
@@ -13,10 +13,6 @@ namespace NebulaNetwork.PacketProcessors.Routers;
 [RegisterPacketProcessor]
 internal class StarBroadcastProcessor : PacketProcessor<StarBroadcastPacket>
 {
-    public StarBroadcastProcessor()
-    {
-    }
-
     protected override void ProcessPacket(StarBroadcastPacket packet, NebulaConnection conn)
     {
         //Forward packet to other users if we're the host

--- a/NebulaNetwork/PacketProcessors/Session/StartGameMessageProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Session/StartGameMessageProcessor.cs
@@ -29,7 +29,7 @@ internal class StartGameMessageProcessor : PacketProcessor<StartGameMessage>
         {
             if (Multiplayer.Session.IsGameLoaded && !GameMain.isFullscreenPaused)
             {
-                INebulaPlayer player = Players.Get(conn, EConnectionStatus.Pending);
+                var player = Players.Get(conn, EConnectionStatus.Pending);
                 if (player is null)
                 {
                     Multiplayer.Session.Server.Disconnect(conn, DisconnectionReason.InvalidData);

--- a/NebulaNetwork/PacketProcessors/Statistics/StatisticsUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Statistics/StatisticsUpdateProcessor.cs
@@ -2,7 +2,6 @@
 
 using NebulaAPI.Packets;
 using NebulaModel.DataStructures;
-using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Statistics;
@@ -74,7 +73,6 @@ internal class StatisticsUpdateProcessor : PacketProcessor<StatisticUpdateDataPa
                 return;
             }
             UIRoot.instance.uiGame.statWindow.OnItemChange();
-            Log.Debug("StatisticsUpdateProcessor: itemChanged");
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Trash/TrashSystemClearAllTrashProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Trash/TrashSystemClearAllTrashProcessor.cs
@@ -14,10 +14,6 @@ namespace NebulaNetwork.PacketProcessors.Trash;
 [RegisterPacketProcessor]
 internal class TrashSystemClearAllTrashProcessor : PacketProcessor<TrashSystemClearAllTrashPacket>
 {
-    public TrashSystemClearAllTrashProcessor()
-    {
-    }
-
     protected override void ProcessPacket(TrashSystemClearAllTrashPacket packet, NebulaConnection conn)
     {
         if (IsHost)

--- a/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereAddShellProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereAddShellProcessor.cs
@@ -26,7 +26,7 @@ internal class DysonSphereAddShellProcessor : PacketProcessor<DysonSphereAddShel
             var shellId = layer.shellRecycleCursor > 0 ? layer.shellRecycle[layer.shellRecycleCursor - 1] : layer.shellCursor;
             if (shellId != packet.ShellId || layer.NewDysonShell(packet.ProtoId, [.. packet.NodeIds]) == 0)
             {
-                Log.Warn($"Cannnot add shell[{packet.ShellId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                Log.Warn($"Cannot add shell[{packet.ShellId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
                 Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                 return;
             }

--- a/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveFrameProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveFrameProcessor.cs
@@ -28,7 +28,7 @@ internal class DysonSphereRemoveFrameProcessor : PacketProcessor<DysonSphereRemo
         {
             if (!Check(layer, packet))
             {
-                Log.Warn($"Cannnot remove frame[{packet.FrameId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                Log.Warn($"Cannot remove frame[{packet.FrameId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
                 Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                 return;
             }

--- a/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveNodeProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveNodeProcessor.cs
@@ -26,7 +26,7 @@ internal class DysonSphereRemoveNodeProcessor : PacketProcessor<DysonSphereRemov
         {
             if (!Check(layer, packet))
             {
-                Log.Warn($"Cannnot remove node[{packet.NodeId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                Log.Warn($"Cannot remove node[{packet.NodeId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
                 Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                 return;
             }

--- a/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveShellProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/Editor/DysonSphereRemoveShellProcessor.cs
@@ -26,7 +26,7 @@ internal class DysonSphereRemoveShellProcessor : PacketProcessor<DysonSphereRemo
         {
             if (packet.ShellId < 1 || packet.ShellId >= layer.shellCursor)
             {
-                Log.Warn($"Cannnot remove shell[{packet.ShellId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
+                Log.Warn($"Cannot remove shell[{packet.ShellId}] on layer[{layer.id}], starIndex[{packet.StarIndex}]");
                 Multiplayer.Session.DysonSpheres.HandleDesync(packet.StarIndex, conn);
                 return;
             }

--- a/NebulaNetwork/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/NameInputProcessor.cs
@@ -1,9 +1,7 @@
 ﻿#region
 
 using NebulaAPI;
-using NebulaAPI.GameState;
 using NebulaAPI.Packets;
-using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
 using NebulaModel.Packets.Universe;
@@ -50,14 +48,12 @@ internal class NameInputProcessor : PacketProcessor<NameInputPacket>
                     var star = galaxyData.StarById(packet.StarIds[i]);
                     star.overrideName = packet.Names[i];
                     star.NotifyOnDisplayNameChange();
-                    Log.Debug($"star{star.id}: {star.name} -> {star.overrideName}");
                 }
                 else
                 {
                     var planet = galaxyData.PlanetById(packet.PlanetIds[i]);
                     planet.overrideName = packet.Names[i];
                     planet.NotifyOnDisplayNameChange();
-                    Log.Debug($"planet{planet.id}: {planet.name} -> {planet.overrideName}");
                 }
             }
             galaxyData.NotifyAstroNameChange();

--- a/NebulaNetwork/PacketProcessors/Universe/NameInputProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Universe/NameInputProcessor.cs
@@ -17,10 +17,6 @@ namespace NebulaNetwork.PacketProcessors.Universe;
 [RegisterPacketProcessor]
 internal class NameInputProcessor : PacketProcessor<NameInputPacket>
 {
-    public NameInputProcessor()
-    {
-    }
-
     protected override void ProcessPacket(NameInputPacket packet, NebulaConnection conn)
     {
         if (IsHost)

--- a/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
@@ -48,10 +48,11 @@ internal class DFRelayComponent_Patch
     [HarmonyPatch(nameof(DFRelayComponent.ArriveBase))]
     public static void ArriveBase_Postfix(DFRelayComponent __instance)
     {
-        if (!Multiplayer.IsActive) return;
+        if (!Multiplayer.IsActive || Multiplayer.Session.IsClient) return;
 
-        var planet = GameMain.galaxy.PlanetById(__instance.targetAstroId);
-        if (planet != null && __instance.baseId > 0)
+        // Display message when DF relay is successfully landed and the planet has buildings
+        var factory = __instance.hive.galaxy.astrosFactory[__instance.targetAstroId];
+        if (factory != null && factory.entityCount > 0 && __instance.baseId > 0)
         {
             Multiplayer.Session.Enemies.DisplayPlanetPingMessage("DF relay landed on planet".Translate(), __instance.targetAstroId, __instance.targetLPos);
         }

--- a/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameSave_Patch.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using HarmonyLib;
 using NebulaModel;
@@ -49,8 +50,8 @@ internal class GameSave_Patch
                 Multiplayer.Session.LocalPlayer.Data.Mecha.SandCount, GameMain.mainPlayer.sandCount);
         }
         // Update last save time in clients
-        GameStatesManager.LastSaveTime = GameMain.gameTick;
-        Multiplayer.Session.Server.SendPacket(new GameStateSaveInfoPacket(GameMain.gameTick));
+        GameStatesManager.LastSaveTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        Multiplayer.Session.Server.SendPacket(new GameStateSaveInfoPacket(GameStatesManager.LastSaveTime));
     }
 
     [HarmonyPrefix]
@@ -96,7 +97,7 @@ internal class GameSave_Patch
         }
         if (Multiplayer.IsActive && Multiplayer.Session.LocalPlayer.IsHost)
         {
-            GameStatesManager.LastSaveTime = GameMain.gameTick;
+            GameStatesManager.LastSaveTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         }
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEscMenu_Patch.cs
@@ -1,5 +1,6 @@
 ﻿#region
 
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using HarmonyLib;
@@ -38,8 +39,8 @@ internal class UIEscMenu_Patch
     {
         if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost) return;
 
-        var timeSinceSave = GameMain.gameTick - GameStatesManager.LastSaveTime;
-        var second = (int)(timeSinceSave / 60L);
+        var timeSinceSave = DateTimeOffset.UtcNow.ToUnixTimeSeconds() - GameStatesManager.LastSaveTime;
+        var second = (int)(timeSinceSave);
         var minute = second / 60;
         var hour = minute / 60;
         var saveBtnText = "存档时间".Translate() + $" {hour}h{minute % 60}m{second % 60}s ago";

--- a/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIGalaxySelect_Patch.cs
@@ -93,9 +93,6 @@ internal class UIGalaxySelect_Patch
 
         if (UIVirtualStarmap_Transpiler.CustomBirthPlanet != -1)
         {
-            Log.Debug(GameMain.data.galaxy.PlanetById(UIVirtualStarmap_Transpiler.CustomBirthPlanet) == null
-                ? "null"
-                : "not null");
             GameMain.data.galaxy.PlanetById(UIVirtualStarmap_Transpiler.CustomBirthPlanet)?.UnloadFactory();
         }
 

--- a/NebulaPatcher/Patches/Transpilers/EnemyDFGroundSystem_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/EnemyDFGroundSystem_Transpiler.cs
@@ -62,7 +62,7 @@ internal class EnemyDFGroundSystem_Transpiler
                     new CodeInstruction(OpCodes.Brtrue_S, jumpOperand)
                 );
 
-            /*  Sync max hatred target before excuting unit behavior in MP                
+            /*  Sync max hatred target before executing unit behavior in MP                
             before:
 				switch (ptr6.behavior)
 				{
@@ -165,8 +165,8 @@ internal class EnemyDFGroundSystem_Transpiler
         {
             var planetId = factory.planetId;
             var starId = factory.planet.star.id;
-            var pakcet = new DFGDeactivateUnitPacket(planetId, id);
-            Multiplayer.Session.Server.SendPacketToStar(pakcet, starId);
+            var packet = new DFGDeactivateUnitPacket(planetId, id);
+            Multiplayer.Session.Server.SendPacketToStar(packet, starId);
         }
     }
 }

--- a/NebulaWorld/GameStates/GameStatesManager.cs
+++ b/NebulaWorld/GameStates/GameStatesManager.cs
@@ -19,7 +19,7 @@ public class GameStatesManager : IDisposable
     public static long RealGameTick => GameMain.gameTick;
     public static float RealUPS => (float)FPSController.currentUPS;
     public static string ImportedSaveName { get; set; }
-    public static long LastSaveTime { get; set; }
+    public static long LastSaveTime { get; set; } // UnixTimeSeconds
     public static GameDesc NewGameDesc { get; set; }
     public static int FragmentSize { get; set; }
 

--- a/NebulaWorld/MultiplayerSession.cs
+++ b/NebulaWorld/MultiplayerSession.cs
@@ -191,7 +191,7 @@ public class MultiplayerSession : IDisposable, IMultiplayerSession
             return;
         }
 
-        Log.Info("Game load completed");
+        Log.Info("==== Game load completed ====");
         IsGameLoaded = true;
         DiscordManager.UpdateRichPresence();
 


### PR DESCRIPTION
This PR contains only UI, Log message changes, and code cleanup. It doesn't change functionality.

- Enable `Log.Debug` in release build
this allows public version to log some low-priority messages (e.g. UPS desync)
the packet sending/receiving messages are still only allowed to display in the debug build
- Fix DF relay landed on planet message in client
this fixes the issue that the landing messages keep showing up in client before host approves the arrival event.
- Fix GameStatesManager.LastSaveTime to use real-world time
Use `DateTimeOffset.ToUnixTimeSeconds` to calculate time difference, avoiding the UPS affect 
- Remove unneeded constructors and Player.Get()
Remove some legacy code. Fix some typo too