### PR TITLE
Removes the requirement of Steam on Headless Server, also a Object Reference fix

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -3,11 +3,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NebulaModel;
 using NebulaModel.Logger;
 using NebulaWorld;
+using Steamworks;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
@@ -171,5 +173,13 @@ internal class Dedicated_Server_Patch
         {
             __instance.isSpherical = true;
         }
+    }
+
+    // Fixes a Object Reference UI error when loading the Headless Server.
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(UICommunicatorIndicator), nameof(UICommunicatorIndicator._OnLateUpdate))]
+    public static bool UICommunicatorIndicatorOnLateUpdate_Prefix()
+    {
+        return false;
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NebulaModel;

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -182,4 +182,39 @@ internal class Dedicated_Server_Patch
     {
         return false;
     }
+
+    #region NoSteamHeadless
+    // This is a set of patches that allows the headless server to start without the need for Steam to be loaded.
+    // This also negates the need to include such things as Goldberg's Steam Emu in Headless server installs.
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(STEAMX), nameof(STEAMX.Awake))]
+    [HarmonyPatch(typeof(SteamLeaderboardManager_PowerConsumption), nameof(SteamLeaderboardManager_PowerConsumption.Start))]
+    [HarmonyPatch(typeof(SteamLeaderboardManager_ClusterGeneration), nameof(SteamLeaderboardManager_ClusterGeneration.Start))]
+    [HarmonyPatch(typeof(SteamLeaderboardManager_SolarSail), nameof(SteamLeaderboardManager_SolarSail.Start))]
+    [HarmonyPatch(typeof(SteamLeaderboardManager_UniverseMatrix), nameof(SteamLeaderboardManager_UniverseMatrix.Start))]
+    [HarmonyPatch(typeof(SteamAchievementManager), nameof(SteamAchievementManager.Start))]
+    [HarmonyPatch(typeof(SteamClient), nameof(SteamClient.SetWarningMessageHook))]
+    public static bool NoSteamHeadless_Prefix(object __instance)
+    {
+        return false;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(SteamManager), nameof(SteamManager.Awake))]
+    public static bool SteamManagerAwake_Prefix(SteamManager __instance)
+    {
+        // Fill out some AccountData so the game has something to work with.
+        AccountData.me.platform = ESalePlatform.Standalone;
+        AccountData.me.userId = 1337u;
+        AccountData.me.detail = new AccountData.Detail() { userName = "NebulaHeadlessAssistant" };
+
+        // Without this, s_instance would never be set which causes some problems later on loading
+        __instance.OnEnable();
+
+        // Force the game to thinking steam has successfully initialised.
+        __instance.m_bInitialized = true;
+
+        return false;
+    }
+    #endregion
 }


### PR DESCRIPTION
This PR adds the needed harmony patches to no longer require Steam for loading the headless server.  This gets rid of the need for server owners to either run steam, or install some Steam Emulator such as Goldberg's, which is what most people are doing now...

It also fixes a Object Reference error during Headless load on UICommunicatorIndicator as there is no UI on load of a headless.

This is my first PR for this project, I hope that everything is in the right places and explained enough - apologies if not.