### PR TITLE
Added UICommunicatorIndicatorOnLateUpdate_Prefix, fixes error during headless startup.

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -161,6 +161,14 @@ internal class Dedicated_Server_Patch
         return false;
     }
 
+    // Fixes a UI Object reference not set error during headless load due to there being no UI enabled.
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(UICommunicatorIndicator), nameof(UICommunicatorIndicator._OnLateUpdate))]
+    public static bool UICommunicatorIndicatorOnLateUpdate_Prefix()
+    {
+        return false;
+    }
+
     [HarmonyPostfix]
     [HarmonyPatch(typeof(PlanetATField), nameof(PlanetATField.RecalculatePhysicsShape))]
     public static void RecalculatePhysicsShape_Postfix(PlanetATField __instance)


### PR DESCRIPTION
Fixes Headless server throwing a small error during boot sequence due to the UI being disabled.