### PR TITLE
No longer initialise DiscordManager on a headless server.

### DIFF
--- a/NebulaPatcher/NebulaPlugin.cs
+++ b/NebulaPatcher/NebulaPlugin.cs
@@ -202,6 +202,9 @@ public class NebulaPlugin : BaseUnityPlugin, IMultiplayerMod
     {
         InitPatches();
         AddNebulaBootstrapper();
+
+        if (Multiplayer.IsDedicated) return; //Do not load discord rich presence on Headless
+
         DiscordManager.Setup(ActivityManager_OnActivityJoin);
     }
 


### PR DESCRIPTION
This stops a skippable error during headless startup too, there is no need to init discord here as the likelihood of it being present is extremely slim.

I've gone through DiscordManager and it looks as though no extra client == null checks are required.