### PR TITLE
Headless now calculates planetary shields on CPU

### DIFF
--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -171,15 +171,47 @@ internal class Dedicated_Server_Patch
         return false;
     }
 
-    [HarmonyPostfix]
+    [HarmonyPrefix]
     [HarmonyPatch(typeof(PlanetATField), nameof(PlanetATField.RecalculatePhysicsShape))]
-    public static void RecalculatePhysicsShape_Postfix(PlanetATField __instance)
+    public static bool RecalculatePhysicsShape_Prefix(PlanetATField __instance)
     {
-        // vanilla use GPU to calculate the shape of shield that is not fully covered the whole planet
-        // In this patch it will act as it has been fully covered to make the planet shield effective
-        if (!__instance.isEmpty)
+        // If we're the server, let's update the planet shields manually.
+        // This is required as checks to planetary shields fail, as there is no GPU to simulate the shields
+        // they become `isEmpty = true`.  This causes some checks to fail such as:
+        //  - Relays still landing on a planet when a shield is online
+        //  - Some space to surface weaponry ignoring the shields
+        if (Multiplayer.IsDedicated)
         {
+            if (__instance.generatorCount == 0)
+            {
+                __instance.ClearPhysics();
+                __instance.energyMaxTarget = 0L;
+            }
+
+            __instance.CreatePhysics();
             __instance.isSpherical = true;
+
+            /*
+             * This is usually computed on the GPU, No idea what math the GPU does though, so we're shoving 0.95 here.
+             * On my own testing this goes as low as 0.35 during initial planet shield spin up
+             * and when it hits 1.0 it seems to stop calling this method.
+             */
+            __instance.energyMaxTarget = (long)(1200000000000.0 * 0.95 + 0.5);
+
+            if (__instance.energy > 0)
+            {
+                __instance.isEmpty = false;
+            }
+
+            // I believe these are used in raycasting tests to see if a relay would hit a shield, so we need them.
+            if (__instance.colliderHotTicks > 0)
+                __instance.OpenColliderObject();
+            else
+                __instance.CloseColliderObject();
+
+            return false;
         }
+
+        return true;
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Dedicated_Server_Patch.cs
@@ -180,38 +180,33 @@ internal class Dedicated_Server_Patch
         // they become `isEmpty = true`.  This causes some checks to fail such as:
         //  - Relays still landing on a planet when a shield is online
         //  - Some space to surface weaponry ignoring the shields
-        if (Multiplayer.IsDedicated)
+        if (__instance.generatorCount == 0)
         {
-            if (__instance.generatorCount == 0)
-            {
-                __instance.ClearPhysics();
-                __instance.energyMaxTarget = 0L;
-            }
-
-            __instance.CreatePhysics();
-            __instance.isSpherical = true;
-
-            /*
-             * This is usually computed on the GPU, No idea what math the GPU does though, so we're shoving 0.95 here.
-             * On my own testing this goes as low as 0.35 during initial planet shield spin up
-             * and when it hits 1.0 it seems to stop calling this method.
-             */
-            __instance.energyMaxTarget = (long)(1200000000000.0 * 0.95 + 0.5);
-
-            if (__instance.energy > 0)
-            {
-                __instance.isEmpty = false;
-            }
-
-            // I believe these are used in raycasting tests to see if a relay would hit a shield, so we need them.
-            if (__instance.colliderHotTicks > 0)
-                __instance.OpenColliderObject();
-            else
-                __instance.CloseColliderObject();
-
-            return false;
+            __instance.ClearPhysics();
+            __instance.energyMaxTarget = 0L;
         }
 
-        return true;
+        __instance.CreatePhysics();
+        __instance.isSpherical = true;
+
+        /*
+            * This is usually computed on the GPU, No idea what math the GPU does though, so we're shoving 0.95 here.
+            * On my own testing this goes as low as 0.35 during initial planet shield spin up
+            * and when it hits 1.0 it seems to stop calling this method.
+            */
+        __instance.energyMaxTarget = (long)(1200000000000.0 * 0.95 + 0.5);
+
+        if (__instance.energy > 0)
+        {
+            __instance.isEmpty = false;
+        }
+
+        // I believe these are used in raycasting tests to see if a relay would hit a shield, so we need them.
+        if (__instance.colliderHotTicks > 0)
+            __instance.OpenColliderObject();
+        else
+            __instance.CloseColliderObject();
+
+        return false;
     }
 }


### PR DESCRIPTION
Currently planet shields do nothing on Headless as they are emptied out and pretty much turned off as it's not possible to simulate how much energy is inside of them as `energy` is set to zero as well as `isEmpty` being set to True.

You can start reading more about this here: https://github.com/NebulaModTeam/nebula/issues/668#issuecomment-2227037945

While I totally understand putting 0.95 here for the headless server to assume that the shield is always attempting to be charged to 95% capacity can be a little bit of a horrible fix, I believe that this is function over form.  I'm sure many of the players running headless would prefer their shields to work as intended, instead of doing nothing.

Running headless also causes a large desync issue with landing relays.  For example if a relay attempts to land on a shielded planet your client will quite rightly dismiss the incoming relay and send it home, but on headless the relay still lands and creates a base.
A handful of times now I have had invisible enemies blowing up my shielded planets structures, just to do a `/r` to see that a enemy base actually exists and is chewing through my buildings.

I noticed during my testing that the RecalculatePhysicsShape method is no longer called once the variable (0.95 in this instance) became a full 1.0f, this value was read-in from the ComputeShader for PlanetAT's.   Setting it to 0.95 seemed to allow the method to be called enough so that the energyMaxTarget was updated quickly enough during the game.

I have been running this patch on my own save for the last 4 days, the instance has also been running while no one is online and not a single relay has managed to land on my planets that have active shields.