### PR TITLE
Enemy Relay Direction Sync

### DIFF
--- a/NebulaModel/Packets/Combat/DFRelay/DFRelayDirectionStateChangePacket.cs
+++ b/NebulaModel/Packets/Combat/DFRelay/DFRelayDirectionStateChangePacket.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NebulaModel.Packets.Combat.DFRelay
+{
+    public class DFRelayDirectionStateChangePacket
+    {
+        public DFRelayDirectionStateChangePacket() { }
+
+        public DFRelayDirectionStateChangePacket(in int relayId, in int hiveAstroId, in int stage, in int newDirection)
+        {
+            HiveAstroId = hiveAstroId;
+            RelayId = relayId;
+            Stage = stage;
+            NewDirection = newDirection;
+        }
+
+        public int HiveAstroId { get; set; }
+        public int RelayId { get; set; }
+        public int Stage { get; set; }
+        public int NewDirection { get; set; }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NebulaAPI.Packets;
+﻿using NebulaAPI.Packets;
 using NebulaModel.Logger;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
@@ -22,8 +17,6 @@ namespace NebulaNetwork.PacketProcessors.Combat.DFRelay
             
             var dfRelayComponent = hiveSystem.relays.buffer[packet.RelayId];
             if (dfRelayComponent?.id != packet.RelayId) return;
-
-            Log.Debug($"Relay {dfRelayComponent.id} direction:{dfRelayComponent.direction} will be sent home with a new direction: {packet.NewDirection}");
 
             switch (packet.NewDirection)
             {

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NebulaAPI.Packets;
+using NebulaModel.Logger;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat.DFRelay;
+using UnityEngine;
+
+namespace NebulaNetwork.PacketProcessors.Combat.DFRelay
+{
+    [RegisterPacketProcessor]
+    public class DFRelayDirectionStateChangeProcessor : PacketProcessor<DFRelayDirectionStateChangePacket>
+    {
+        protected override void ProcessPacket(DFRelayDirectionStateChangePacket packet, NebulaConnection conn)
+        {
+            var hiveSystem = GameMain.spaceSector.GetHiveByAstroId(packet.HiveAstroId);
+            if (hiveSystem == null) return;
+            
+            var dfRelayComponent = hiveSystem.relays.buffer[packet.RelayId];
+            if (dfRelayComponent?.id != packet.RelayId) return;
+
+            Log.Debug($"Relay {dfRelayComponent.id} direction:{dfRelayComponent.direction} will be sent home with a new direction: {packet.NewDirection}");
+
+            switch (packet.NewDirection)
+            {
+                case -1: //Relay is being sent home
+                    dfRelayComponent.targetAstroId = 0;
+                    dfRelayComponent.targetLPos = Vector3.zero;
+                    dfRelayComponent.targetYaw = 0f;
+                    dfRelayComponent.baseState = 0;
+                    dfRelayComponent.baseId = 0;
+                    dfRelayComponent.baseTicks = 0;
+                    dfRelayComponent.baseEvolve = default(EvolveData);
+                    dfRelayComponent.baseRespawnCD = 0;
+                    dfRelayComponent.direction = -1;
+                    dfRelayComponent.param0 = 0f;
+
+                    dfRelayComponent.stage = packet.Stage;
+
+                    Log.Debug($"Relay {dfRelayComponent.id} returning home");
+                    break;
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
+++ b/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using HarmonyLib;
+using System.Reflection.Emit;
+using NebulaModel.Logger;
+using NebulaModel.Packets.Combat.DFRelay;
+using NebulaWorld;
+
+namespace NebulaPatcher.Patches.Transpilers
+{
+    [HarmonyPatch(typeof(DFRelayComponent))]
+    internal class EnemyDFRelayComponent_Transplier
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(DFRelayComponent.RelaySailLogic))]
+        public static IEnumerable<CodeInstruction> RelaySailLogic_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            try
+            {
+                // Attempt to match anywhere where `direction = -1` is set.
+                // Change to:
+                // direction = -1
+                // call UpdateRelayDirectionState(relayId, hive)
+
+                var codeMatcher = new CodeMatcher(instructions);
+                codeMatcher.MatchForward(true,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldc_I4_M1),
+                    new CodeMatch(i => i.opcode == OpCodes.Stfld && ((FieldInfo)i.operand).Name == "direction"));
+
+                if (codeMatcher.IsInvalid)
+                {
+                    Log.Error("Transpiler DFRelayComponent.RelaySailLogic matcher is not valid. Mod version not compatible with game version.");
+                    return instructions;
+                }
+
+                codeMatcher.Repeat(matcher =>
+                {
+                    matcher.InsertAndAdvance(
+                        // Relay ID argument
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldfld,
+                            AccessTools.Field(typeof(DFRelayComponent), nameof(DFRelayComponent.id))),
+
+                        // Hive Astro ID argument
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldfld,
+                            AccessTools.Field(typeof(DFRelayComponent), nameof(DFRelayComponent.stage))),
+
+                        // Hive Astro ID argument
+                        new CodeInstruction(OpCodes.Ldarg_0),
+                        new CodeInstruction(OpCodes.Ldfld,
+                            AccessTools.Field(typeof(DFRelayComponent), nameof(DFRelayComponent.hiveAstroId))),
+
+                        //Call our method
+                        new CodeInstruction(OpCodes.Call,
+                            AccessTools.Method(typeof(EnemyDFRelayComponent_Transplier),
+                                nameof(RelaySendBackToHiveDock))));
+                }
+                );
+
+                return codeMatcher.InstructionEnumeration();
+            }
+            catch (Exception e)
+            {
+                Log.Error("Transpiler DFRelayComponent.RelaySailLogic failed. Mod version not compatible with game version.");
+                Log.Error(e);
+                return instructions;
+            }
+        }
+
+        static void RelaySendBackToHiveDock(int relayId, int stage, int hiveAstroId)
+        {
+            // This is only called when the RelaySailTick has told the relay to return back to the hive and dock.
+            Log.Debug($"RelaySendBackToHiveDock called for relay ID {relayId} belonging to hive {hiveAstroId}");
+
+            if (!Multiplayer.IsActive) return;
+            if (!Multiplayer.Session.IsClient)
+            {
+                Multiplayer.Session.Network.SendPacket(new DFRelayDirectionStateChangePacket(relayId, hiveAstroId, stage, -1));
+            }
+        }
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
+++ b/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
@@ -57,9 +57,8 @@ namespace NebulaPatcher.Patches.Transpilers
                         //Call our method
                         new CodeInstruction(OpCodes.Call,
                             AccessTools.Method(typeof(EnemyDFRelayComponent_Transplier),
-                                nameof(RelaySendBackToHiveDock))));
-                }
-                );
+                                nameof(ReplicateRelayDirectionChange))));
+                });
 
                 return codeMatcher.InstructionEnumeration();
             }
@@ -71,11 +70,8 @@ namespace NebulaPatcher.Patches.Transpilers
             }
         }
 
-        static void RelaySendBackToHiveDock(int relayId, int stage, int hiveAstroId)
+        static void ReplicateRelayDirectionChange(int relayId, int stage, int hiveAstroId)
         {
-            // This is only called when the RelaySailTick has told the relay to return back to the hive and dock.
-            Log.Debug($"RelaySendBackToHiveDock called for relay ID {relayId} belonging to hive {hiveAstroId}");
-
             if (!Multiplayer.IsActive) return;
             if (!Multiplayer.Session.IsClient)
             {

--- a/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
+++ b/NebulaPatcher/Patches/Transpilers/EnemyDFRelayComponent_Transplier.cs
@@ -44,7 +44,7 @@ namespace NebulaPatcher.Patches.Transpilers
                         new CodeInstruction(OpCodes.Ldfld,
                             AccessTools.Field(typeof(DFRelayComponent), nameof(DFRelayComponent.id))),
 
-                        // Hive Astro ID argument
+                        // Relay sail stage argument
                         new CodeInstruction(OpCodes.Ldarg_0),
                         new CodeInstruction(OpCodes.Ldfld,
                             AccessTools.Field(typeof(DFRelayComponent), nameof(DFRelayComponent.stage))),


### PR DESCRIPTION
As explained a little in https://github.com/NebulaModTeam/nebula/pull/692, I have now implemented Relay Direction Sync for when a relay is told to return back to the hive.

Creating a new PR for this as it isnt exactly related to the PR linked above.

Here is a client & server setup.
Server: Player on the planet where the relay is going to
Client: In a different solar system, watching the relay via the starmap.

![image](https://github.com/user-attachments/assets/c5e18cd3-b7e0-43af-9abf-713e384cb17d)

- [x] The host now sends the relay back to the hive on all connected clients.
- [x] This also fixes relays landing on planets when a player is not in the same solar system as the landing relay. 