### PR TITLE
Bugfix 2024-07-20

### DIFF
--- a/NebulaModel/Networking/Serialization/NebulaNetPacketProcessor.cs
+++ b/NebulaModel/Networking/Serialization/NebulaNetPacketProcessor.cs
@@ -131,7 +131,6 @@ public class NebulaNetPacketProcessor : NetPacketProcessor, INetPacketProcessor
         lock (pendingPackets)
         {
             pendingPackets.Enqueue(new PendingPacket(rawData, userData));
-            Log.Debug($"Received packet of size: {rawData.Length}");
         }
     }
 

--- a/NebulaModel/Packets/Combat/DFRelay/DFRelayDirectionStateChangePacket.cs
+++ b/NebulaModel/Packets/Combat/DFRelay/DFRelayDirectionStateChangePacket.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace NebulaModel.Packets.Combat.DFRelay
+﻿namespace NebulaModel.Packets.Combat.DFRelay
 {
     public class DFRelayDirectionStateChangePacket
     {

--- a/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/DFRelay/DFRelayDirectionStateChangeProcessor.cs
@@ -14,7 +14,7 @@ namespace NebulaNetwork.PacketProcessors.Combat.DFRelay
         {
             var hiveSystem = GameMain.spaceSector.GetHiveByAstroId(packet.HiveAstroId);
             if (hiveSystem == null) return;
-            
+
             var dfRelayComponent = hiveSystem.relays.buffer[packet.RelayId];
             if (dfRelayComponent?.id != packet.RelayId) return;
 
@@ -27,11 +27,10 @@ namespace NebulaNetwork.PacketProcessors.Combat.DFRelay
                     dfRelayComponent.baseState = 0;
                     dfRelayComponent.baseId = 0;
                     dfRelayComponent.baseTicks = 0;
-                    dfRelayComponent.baseEvolve = default(EvolveData);
+                    dfRelayComponent.baseEvolve = default;
                     dfRelayComponent.baseRespawnCD = 0;
                     dfRelayComponent.direction = -1;
                     dfRelayComponent.param0 = 0f;
-
                     dfRelayComponent.stage = packet.Stage;
 
                     Log.Debug($"Relay {dfRelayComponent.id} returning home");

--- a/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DFRelayComponent_Patch.cs
@@ -107,11 +107,22 @@ internal class DFRelayComponent_Patch
     {
         if (!Multiplayer.IsActive || Multiplayer.Session.IsServer) return true;
 
-        if (__instance.baseState == 2 && __instance.hive.galaxy.astrosFactory[__instance.targetAstroId] == null)
+        if (__instance.baseState == DFRelayComponent.REALIZED_BASE && __instance.hive.galaxy.astrosFactory[__instance.targetAstroId] == null)
         {
             //the target factory is not loaded on client
             return false;
         }
         return true;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(DFRelayComponent.RelaySailLogic))]
+    public static void RelaySailLogic_Prefix(ref bool keyFrame)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.IsServer) return;
+
+        // Prevent clients from changing the direction or stage themselves
+        // The changing event is server autoreactive (DFRelayDirectionStateChangePacket)
+        keyFrame = false;
     }
 }

--- a/NebulaPatcher/Patches/Dynamic/SkillSystem_Common_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/SkillSystem_Common_Patch.cs
@@ -11,8 +11,20 @@ namespace NebulaPatcher.Patches.Dynamic;
 internal class SkillSystem_Common_Patch
 {
     [HarmonyPrefix]
-    [HarmonyPatch(typeof(GeneralShieldBurst), nameof(GeneralShieldBurst.TickSkillLogic))]
+    [HarmonyPatch(typeof(Bomb_Explosive), nameof(Bomb_Explosive.TickSkillLogic))]
+    [HarmonyPatch(typeof(Bomb_Liquid), nameof(Bomb_Liquid.TickSkillLogic))]
+    [HarmonyPatch(typeof(Bomb_EMCapsule), nameof(Bomb_EMCapsule.TickSkillLogic))]
+    public static void Bomb_TickSkillLogic(ref int ___nearPlanetAstroId, ref int ___life)
+    {
+        if (___nearPlanetAstroId > 0 && GameMain.spaceSector.skillSystem.astroFactories[___nearPlanetAstroId] == null)
+        {
+            // The nearest planetFactory hasn't loaded yet, skip and remove
+            ___life = 0;
+        }
+    }
 
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(GeneralShieldBurst), nameof(GeneralShieldBurst.TickSkillLogic))]
     public static bool GeneralShieldBurst_Prefix(ref GeneralShieldBurst __instance, SkillSystem skillSystem)
     {
         if (!Multiplayer.IsActive || __instance.caster.type != ETargetType.Player) return true;

--- a/NebulaWorld/Combat/EnemyManager.cs
+++ b/NebulaWorld/Combat/EnemyManager.cs
@@ -126,6 +126,8 @@ public class EnemyManager : IDisposable
         {
             var enemyId = unitBuffer[i].enemyId;
             targets[enemyId] = unitBuffer[i].hatred.max.target;
+            // clear the blocking skill to prevent error due to skills are not all present in client
+            unitBuffer[i].ClearBlockSkill();
         }
     }
 


### PR DESCRIPTION
1. Fix RunBehavior_Defense_Ground error when client load planet. 
```
IndexOutOfRangeException: Index was outside the bounds of the array.
EnemyUnitComponent.RunBehavior_Defense_Ground(System.Int32 formTick, SkillSystem skillSystem, EnemyData[] enemyPool, DFGBaseComponent[] bases, System.Single altitude, EnemyData& enemy);(IL_028B)
```

2. Fix error when other players throwing bombs due to accessing the null planetFactory
This seems to due to the position is wrong when the other player is not on the same local planet.
```
NullReferenceException: Object reference not set to an instance of an object
Bomb_Explosive.TickSkillLogic (SkillSystem skillSystem, System.Int64 time);(IL_03BE)
```

3. Set DFRelayComponent.RelaySailLogic keyFrame = false in client  
The direction change event is authorized by server (#693)

4. Remove packet size debug log in release build  
to prevent log spamming when log level has Debug

