### PR TITLE
Sync damage to space enemy by mecha fleet

### DIFF
--- a/NebulaModel/Packets/Combat/CombatStatDamagePacket.cs
+++ b/NebulaModel/Packets/Combat/CombatStatDamagePacket.cs
@@ -1,0 +1,29 @@
+﻿using System.Security.Policy;
+
+namespace NebulaModel.Packets.Combat;
+
+public class CombatStatDamagePacket
+{
+    public CombatStatDamagePacket() { }
+
+    public CombatStatDamagePacket(int damage, int slice, in SkillTarget target, in SkillTarget caster)
+    {
+        Damage = damage;
+        Slice = slice;
+        TargetType = (short)target.type;
+        TargetId = target.id;
+        TargetAstroId = target.astroId;
+        CasterType = (short)caster.type;
+        CasterId = caster.id;
+        CasterAstroId = caster.astroId;
+    }
+
+    public int Damage { get; set; }
+    public int Slice { get; set; }
+    public short TargetType { get; set; }
+    public int TargetId { get; set; }
+    public int TargetAstroId { get; set; }
+    public short CasterType { get; set; }
+    public int CasterId { get; set; }
+    public int CasterAstroId { get; set; }
+}

--- a/NebulaNetwork/PacketProcessors/Combat/CombatStatDamageProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/CombatStatDamageProcessor.cs
@@ -1,0 +1,54 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Combat;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Combat;
+
+[RegisterPacketProcessor]
+public class CombatStatDamageProcessor : PacketProcessor<CombatStatDamagePacket>
+{
+    protected override void ProcessPacket(CombatStatDamagePacket packet, NebulaConnection conn)
+    {
+        if (IsHost)
+        {
+            Multiplayer.Session.Server.SendPacketExclude(packet, conn);
+        }
+
+        SkillTarget target;
+        target.type = (ETargetType)packet.TargetType;
+        target.id = packet.TargetId;
+        target.astroId = packet.TargetAstroId;
+        SkillTarget caster;
+        caster.type = (ETargetType)packet.CasterType;
+        caster.id = packet.CasterId;
+        caster.astroId = packet.CasterAstroId;
+
+        if (target.type != ETargetType.Enemy) return; // Guard
+
+        var astroId = target.astroId;
+        if (astroId > 1000000)
+        {
+            if (target.id >= GameMain.spaceSector.enemyPool.Length)
+            {
+                // Return if enemyId is not exist in client
+                return;
+            }
+        }
+        else if (astroId > 100 && astroId <= 204899 && astroId % 100 > 0)
+        {
+            var factory = GameMain.spaceSector.skillSystem.astroFactories[astroId];
+            if (factory == null || target.id >= factory.enemyPool.Length) return;
+        }
+
+        using (Multiplayer.Session.Combat.IsIncomingRequest.On())
+        {
+            GameMain.spaceSector.skillSystem.DamageObject(packet.Damage, packet.Slice, ref target, ref caster);
+        }
+    }
+}


### PR DESCRIPTION
When the mecha fleet attacks space enemy units such as Relays and Hives, it broadcasts the damage dealt to other players. This process also synchronizes the increase in hive threat caused by the attacks.

This is a temporary workaround as the mecha fleet are not synchronized yet. However, a downside is that each attack sends a 36-byte packet, leading to high-frequency packet transmissions during intense space battles.

