### PR TITLE
Combat balance change and bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+0.9.10:
+- @fakeboboliu: Support to connect server with WSS by specifying wss:// in the connect Uri
+- @starfi5h: Sync Logistics Control Panel (I) entry list
+- @starfi5h: Esc in multiplayer menu can now return to the upper-level
+- @starfi5h: (Balance) When player killed, Drop half of item in inventory and increase CD from 1.5s to 5s
+- @starfi5h: (Balance) Increase base alert range to player from 90 to 200
+- @starfi5h: Space hive threat will now increase correctly when client attack relays by player's fleet
+- @starfi5h: DF base/hive will now launch attack at player on remote empty planet too
+- @starfi5h: Fix client player can't see the death animation of other clients
+- @starfi5h: Fix DF base sometimes can't be destroyed in client
+- @starfi5h: (Headless server) Stop relay landing when there are 7 or more working shield generators
+
 0.9.9:
 - @starfi5h: Fix multiplayer tab in the option window for DSP v0.10.30.23430
 - @starfi5h: Separate error close button (x) and copy button

--- a/NebulaNetwork/PacketProcessors/Combat/CombatStatDamageProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/CombatStatDamageProcessor.cs
@@ -17,7 +17,10 @@ public class CombatStatDamageProcessor : PacketProcessor<CombatStatDamagePacket>
     {
         if (IsHost)
         {
-            Multiplayer.Session.Server.SendPacketExclude(packet, conn);
+            if (packet.TargetAstroId > 1000000)
+            {
+                Multiplayer.Session.Server.SendPacketExclude(packet, conn);
+            }
         }
 
         SkillTarget target;
@@ -48,7 +51,11 @@ public class CombatStatDamageProcessor : PacketProcessor<CombatStatDamagePacket>
 
         using (Multiplayer.Session.Combat.IsIncomingRequest.On())
         {
-            GameMain.spaceSector.skillSystem.DamageObject(packet.Damage, packet.Slice, ref target, ref caster);
+            var skillSystem = GameMain.spaceSector.skillSystem;
+            var tmp = skillSystem.playerAlive;
+            skillSystem.playerAlive = true;
+            skillSystem.DamageObject(packet.Damage, packet.Slice, ref target, ref caster);
+            skillSystem.playerAlive = tmp;
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Combat/Mecha/MechaAliveEventProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Combat/Mecha/MechaAliveEventProcessor.cs
@@ -15,6 +15,11 @@ public class MechaAliveEventProcessor : PacketProcessor<MechaAliveEventPacket>
 {
     protected override void ProcessPacket(MechaAliveEventPacket packet, NebulaConnection conn)
     {
+        if (IsHost)
+        {
+            Multiplayer.Session.Server.SendPacketExclude(packet, conn);
+        }
+
         using (Multiplayer.Session.World.GetRemotePlayersModels(out var remotePlayersModels))
         {
             if (!remotePlayersModels.TryGetValue(packet.PlayerId, out var playerModel)) return;

--- a/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Logistics/StationUIInitialSyncRequestProcessor.cs
@@ -30,7 +30,7 @@ public class StationUIInitialSyncRequestProcessor : PacketProcessor<StationUIIni
 
         if (stationComponent == null)
         {
-            Log.Error(
+            Log.Warn(
                 $"StationUIInitialSyncRequestProcessor: Unable to find requested station on planet {packet.PlanetId} with id {packet.StationId} and gid {packet.StationGId}");
             return;
         }

--- a/NebulaPatcher/Patches/Dynamic/DFGBaseComponent_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/DFGBaseComponent_Patch.cs
@@ -197,7 +197,8 @@ internal class DFGBaseComponent_Patch
         for (var pid = 0; pid < players.Length; pid++)
         {
             if (players[pid].planetId != planetId) continue;
-            if (((Vector3)enemyPool[__instance.enemyId].pos - players[pid].position).sqrMagnitude < 8100.0)
+            // Balance: Increase base player alert range from 90 to 200
+            if (((Vector3)enemyPool[__instance.enemyId].pos - players[pid].position).sqrMagnitude < 40000.0)
             {
                 __instance.UnderAttack(players[pid].position, 50f, 120);
             }

--- a/NebulaPatcher/Patches/Dynamic/EnemyDFGroundSystem_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/EnemyDFGroundSystem_Patch.cs
@@ -79,6 +79,31 @@ internal class EnemyDFGroundSystem_Patch
     }
 
     [HarmonyPrefix]
+    [HarmonyPatch(nameof(EnemyDFGroundSystem.CanEraseBase))]
+    public static bool CanEraseBase_Prefix(DFGBaseComponent _base, ref bool __result)
+    {
+        if (!Multiplayer.IsActive) return true;
+
+        if (_base == null || _base.id == 0)
+        {
+            __result = true;
+            return false;
+        }
+        // Skip __instance.builders.buffer[_base.builderId].sp check as it may have different value
+        var pbuilders = _base.pbuilders;
+        for (var i = 2; i < pbuilders.Length; i++)
+        {
+            if (pbuilders[i].instId > 0)
+            {
+                __result = false;
+                return false;
+            }
+        }
+        __result = true;
+        return false;
+    }
+
+    [HarmonyPrefix]
     [HarmonyPatch(nameof(EnemyDFGroundSystem.NotifyEnemyKilled))]
     public static bool NotifyEnemyKilled_Prefix()
     {

--- a/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlanetData_Patch.cs
@@ -35,12 +35,8 @@ internal class PlanetData_Patch
         {
             return true;
         }
-        Log.Warn(__instance == GameMain.localPlanet
-            ? "Local"
-            : "Remote" + $" PlanetData.UpdateDirtyMesh: meshes[{dirtyIdx}] is null");
         __result = false;
         return false;
-
     }
 
     [HarmonyPrefix]

--- a/NebulaPatcher/Patches/Dynamic/PlayerAction_Death_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/PlayerAction_Death_Patch.cs
@@ -16,7 +16,7 @@ internal class PlayerAction_Death_Patch
     [HarmonyPatch(nameof(PlayerAction_Death.Respawn))]
     public static void Respawn_Prefix(PlayerAction_Death __instance, int _respawnMode)
     {
-        if (!Multiplayer.IsActive) return;
+        if (!Multiplayer.IsActive || __instance.player != GameMain.mainPlayer) return;
 
         if (!__instance.player.isAlive && !__instance.respawning)
         {

--- a/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/Player_Patch.cs
@@ -164,6 +164,7 @@ internal class Player_Patch
         {
             Multiplayer.Session.Network.SendPacket(new MechaAliveEventPacket(
                 Multiplayer.Session.LocalPlayer.Id, MechaAliveEventPacket.EStatus.Kill));
+            ThrowItemsInInventory(__instance);
         }
         return true;
     }
@@ -177,6 +178,22 @@ internal class Player_Patch
         // Don't drop item when Redeploy
         __instance.mecha.PrepareRedeploy();
         return false;
+    }
+
+    private static void ThrowItemsInInventory(Player player)
+    {
+        // Balance: Drop half of item in inventory when player killed
+        const float DROP_RATE = 0.5f;
+        for (var i = 0; i < player.package.size; i++)
+        {
+            var itemId = 0;
+            var itemCount = (int)(player.package.grids[i].count * DROP_RATE);
+            player.package.TakeItemFromGrid(i, ref itemId, ref itemCount, out var itemInc);
+            if (itemId > 0 && itemCount > 0)
+            {
+                player.ThrowTrash(itemId, itemCount, itemInc, 0, 0);
+            }
+        }
     }
 
     #endregion

--- a/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIMainMenu_Patch.cs
@@ -73,6 +73,31 @@ internal class UIMainMenu_Patch
         OnMultiplayerBackButtonClick();
     }
 
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIMainMenu.UpdateDemoScene))]
+    [HarmonyPatch(nameof(UIMainMenu._OnUpdate))]
+    public static void OnEscSwitch()
+    {
+        if (!VFInput.escape) return;
+
+        // Go back to the upper level when hitting esc
+        if (multiplayerMenu.gameObject.activeInHierarchy)
+        {
+            OnJoinGameBackButtonClick();
+            VFInput.UseEscape();
+        }
+        else if (UIRoot.instance.loadGameWindow.active)
+        {
+            UIRoot.instance.loadGameWindow.OnCancelClick(0);
+            VFInput.UseEscape();
+        }
+        else if (multiplayerSubMenu.gameObject.activeInHierarchy)
+        {
+            OnMultiplayerBackButtonClick();
+            VFInput.UseEscape();
+        }
+    }
+
     // Main Menu
     private static void AddMultiplayerButton()
     {

--- a/NebulaPatcher/Patches/Misc/Dedicated_Server_Patches.cs
+++ b/NebulaPatcher/Patches/Misc/Dedicated_Server_Patches.cs
@@ -209,4 +209,12 @@ internal class Dedicated_Server_Patches
 
         return false;
     }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(PlanetATField), nameof(PlanetATField.TestRelayCondition))]
+    public static void StopLanding(PlanetATField __instance, ref bool __result)
+    {
+        // Balance: Stop relay landing when there are 7 or more working shield generators
+        __result &= !(__instance.energy > 0 && __instance.generatorCount >= 7);
+    }
 }

--- a/NebulaPatcher/Patches/Transpilers/DFGBaseComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/DFGBaseComponent_Transpiler.cs
@@ -1,0 +1,86 @@
+﻿#region
+
+using System.Collections.Generic;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Transpilers;
+
+[HarmonyPatch(typeof(DFGBaseComponent))]
+internal class DFGBaseComponent_Transpiler
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(DFGBaseComponent.UpdateFactoryThreat))]
+    public static IEnumerable<CodeInstruction> UpdateFactoryThreat_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        try
+        {
+            /*  Launch assault for player who on remote planet and has no power buildings
+            from:
+				if (num24 == 0.0 && this.groundSystem.local_player_grounded_alive)
+                {
+					num24 = 10.0;
+					ref Vector3 ptr2 = ref this.groundSystem.local_player_pos;
+					vector = new Vector3(ptr2.x - num, ptr2.y - num2, ptr2.z - num3);
+					num18 = num16;
+					num19 = num17;
+                }
+            to:
+			>>	if (num24 == 0.0 && LaunchCondition(this))
+                {
+                    ...
+                }
+            */
+
+            var codeMatcher = new CodeMatcher(instructions)
+                .End()
+                .MatchBack(true,
+                    new CodeMatch(OpCodes.Ldloc_S),
+                    new CodeMatch(OpCodes.Ldc_R8),
+                    new CodeMatch(OpCodes.Bne_Un),
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(DFGBaseComponent), nameof(DFGBaseComponent.groundSystem))),
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(EnemyDFGroundSystem), nameof(EnemyDFGroundSystem.local_player_grounded_alive))),
+                    new CodeMatch(OpCodes.Brfalse));
+
+            if (codeMatcher.IsInvalid)
+            {
+                Log.Warn("DFGBaseComponent.UpdateFactoryThreat: Can't find target");
+                return codeMatcher.InstructionEnumeration();
+            }
+            codeMatcher.Advance(-2)
+                .RemoveInstruction()
+                .SetAndAdvance(OpCodes.Call, AccessTools.Method(typeof(DFGBaseComponent_Transpiler), nameof(LaunchCondition)));
+
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (System.Exception e)
+        {
+            Log.Warn("Transpiler DFGBaseComponent.UpdateFactoryThreat failed.");
+            Log.Warn(e);
+            return instructions;
+        }
+    }
+
+    static bool LaunchCondition(DFGBaseComponent @this)
+    {
+        if (!Multiplayer.IsActive || @this.groundSystem.local_player_alive == true) return @this.groundSystem.local_player_alive;
+
+        var planetId = @this.groundSystem.planet.id;
+        var players = Multiplayer.Session.Combat.Players;
+        for (var i = 0; i < players.Length; i++)
+        {
+            if (players[i].isAlive && players[i].planetId == planetId)
+            {
+                @this.groundSystem.local_player_pos = players[i].position;
+                Log.Info($"Base attack LaunchCondition: player[{i}] planeId{planetId}");
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/UIDeathPanel_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIDeathPanel_Transpiler.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Reflection.Emit;
 using HarmonyLib;
 using NebulaModel.Logger;
@@ -45,6 +46,35 @@ internal class UIDeathPanel_Transpiler
         catch (Exception e)
         {
             Log.Warn("Transpiler UIDeathPanel fail!");
+            Log.Warn(e);
+            return instructions;
+        }
+    }
+
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(UIDeathPanel.Determine))]
+    public static IEnumerable<CodeInstruction> Determine_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        try
+        {
+            // Balance: Change the delay of UIDeathPanel showing up after death from 1.5s to 5.0s
+            // from: if (this.timeSinceKilledF > 1.5f && !GameMain.mainPlayer.respawning)
+            // to:   if (this.timeSinceKilledF > UIOPEN_DELAY && !GameMain.mainPlayer.respawning)
+            const float UIOPEN_DELAY = 5.0f;
+            var codeMatcher = new CodeMatcher(instructions)
+                .MatchForward(true,
+                    new CodeMatch(OpCodes.Ldarg_0),
+                    new CodeMatch(i => i.opcode == OpCodes.Ldfld && ((FieldInfo)i.operand).Name == "timeSinceKilledF"),
+                    new CodeMatch(OpCodes.Ldc_R4),
+                    new CodeMatch(OpCodes.Ble_Un))
+                .Advance(-1)
+                .SetOperandAndAdvance(UIOPEN_DELAY);
+
+            return codeMatcher.InstructionEnumeration();
+        }
+        catch (Exception e)
+        {
+            Log.Warn("Transpiler UIDeathPanel.Determine fail!");
             Log.Warn(e);
             return instructions;
         }

--- a/NebulaWorld/Combat/CombatManager.cs
+++ b/NebulaWorld/Combat/CombatManager.cs
@@ -137,7 +137,7 @@ public class CombatManager : IDisposable
                 mecha.energyShieldEnergy = mecha.energyShieldEnergyRate > 1 ? 0 : int.MaxValue;
 
                 ActivedPlanets.Add(ptr.planetId);
-                ActivedPlanets.Add(ptr.starId);
+                ActivedStars.Add(ptr.starId);
                 if (ptr.planetId <= 0 && ptr.starId > 0)
                 {
                     ActivedStarsMechaInSpace.Add(ptr.starId);

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Most of the battle aspects are sync, only few features are still WIP.
 - [x] Power network syncing (charger and request power from dyson sphere)
 - [x] Warning alarm syncing
 - [x] Broadcast notification syncing (events with guide icon)
-- [ ] Logistics Control Panel (I) syncing
+- [x] Logistics Control Panel (I) syncing (entry list without detail panel)
 
 </details>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
**Add**
Esc in multiplayer menu can now return to the upper-level

**Combat Balance Change**
When player is killed, Drop half of item in inventory and increase CD from 1.5s to 5s
Increase DF base player alert range from 90 to 200
(Headless server) Stop relay landing when there are 7 or more working shield generators

**Combat Bugfix**
Space hive threat will now increase correctly when client attack relays by player's fleet
DF base/hive will now launch attack at player on remote empty planet too
Fix client player can't see the death animation of other clients
Fix DF base sometimes can't be destroyed in client