### PR TITLE
Bugfix 2024-09-14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+0.9.11:
+- @starfi5h: Fix half-growth dark fog bases keep regenerating
+- @starfi5h: Fix combat drones doesn't increase ground base threat
+- @starfi5h: Fix errors in NgrokManager.IsNgrokActive and SpaceSector.RemoveEnemyWithComponents
+
 0.9.10:
 - @fakeboboliu: Support to connect server with WSS by specifying wss:// in the connect Uri
 - @starfi5h: Sync Logistics Control Panel (I) entry list

--- a/NebulaModel/Logger/Log.cs
+++ b/NebulaModel/Logger/Log.cs
@@ -68,8 +68,12 @@ public static class Log
             {
                 // ShowError has Unity API and needs to call on the main thread
                 BepInEx.ThreadingHelper.Instance.StartSyncInvoke(() =>
-                    UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "")
-                );
+                {
+                    // We just want to use the window to show the error message, so leave GameMain.errored as the original value
+                    var tmp = GameMain.errored;
+                    UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "");
+                    GameMain.errored = tmp;
+                });
                 return;
             }
             UIFatalErrorTip.instance.ShowError("[Nebula Error] " + message, "");

--- a/NebulaNetwork/Ngrok/NgrokManager.cs
+++ b/NebulaNetwork/Ngrok/NgrokManager.cs
@@ -188,13 +188,13 @@ public class NgrokManager
             // This links the process as a child process by attaching a null debugger thus ensuring that the process is killed when its parent dies.
             _ = new ChildProcessLinker(_ngrokProcess, _ =>
             {
-                Log.Warn(
+                Log.WarnInform(
                     "Failed to link Ngrok process to DSP process as a child! (This might result in a left over ngrok process if the DSP process uncleanly killed)");
             });
         }
         else
         {
-            Log.Error("Failed to start Ngrok process!");
+            Log.WarnInform("Failed to start Ngrok process!");
         }
 
         _ngrokProcess?.BeginOutputReadLine();
@@ -286,7 +286,7 @@ public class NgrokManager
         }
         catch (Exception e)
         {
-            Log.Error(e);
+            Log.WarnInform(e.ToString());
         }
         _ngrokProcess.Close();
         _ngrokProcess = null;
@@ -301,7 +301,7 @@ public class NgrokManager
         }
         catch (Exception e)
         {
-            Log.Error(e);
+            Log.WarnInform(e.ToString());
             return false;
         }
     }
@@ -310,12 +310,6 @@ public class NgrokManager
     {
         return Task.Run(() =>
         {
-            if (!IsNgrokActive())
-            {
-                throw new Exception(
-                    $"Not able to get Ngrok tunnel address because Ngrok is not started (or exited prematurely)! LastErrorCode: {NgrokLastErrorCode} {NgrokLastErrorCodeDesc}");
-            }
-
             if (!_ngrokAddressObtainedSource.Task.Wait(TimeSpan.FromSeconds(15)))
             {
                 throw new TimeoutException(

--- a/NebulaPatcher/Patches/Dynamic/SpaceSector_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/SpaceSector_Patch.cs
@@ -54,6 +54,22 @@ internal class SpaceSector_Patch
     }
 
     [HarmonyPrefix]
+    [HarmonyPatch(nameof(SpaceSector.RemoveEnemyWithComponents))]
+    public static void RemoveEnemyWithComponents_Prefix(SpaceSector __instance, int id)
+    {
+        // Fix IndexOutOfRangeException in SpaceSector.RemoveEnemyWithComponents IL_026A 
+        // This is due to combatStats is not sync in client
+        if (id != 0 && __instance.enemyPool[id].id != 0)
+        {
+            if (__instance.enemyPool[id].combatStatId != 0)
+            {
+                if (__instance.enemyPool[id].combatStatId >= __instance.skillSystem.combatStats.cursor)
+                    __instance.enemyPool[id].combatStatId = 0;
+            }
+        }
+    }
+
+    [HarmonyPrefix]
     [HarmonyPatch(nameof(SpaceSector.TryCreateNewHive))]
     public static bool TryCreateNewHive_Prefix(StarData star)
     {

--- a/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
@@ -186,7 +186,7 @@ internal class UIFatalErrorTip_Patch
             }
 
             // Nebula only: skip the message after PacketProcessor
-            if (str.StartsWith("NebulaModel.Packets.PacketProcessor"))
+            if (str.StartsWith("NebulaModel.Packets.PacketProcessor") || str.StartsWith("  at NebulaModel.Packets.PacketProcessor"))
             {
                 break;
             }

--- a/NebulaPatcher/Patches/Transpilers/DFGBaseComponent_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/DFGBaseComponent_Transpiler.cs
@@ -68,8 +68,9 @@ internal class DFGBaseComponent_Transpiler
 
     static bool LaunchCondition(DFGBaseComponent @this)
     {
-        if (!Multiplayer.IsActive || @this.groundSystem.local_player_alive == true) return @this.groundSystem.local_player_alive;
+        if (!Multiplayer.IsActive) return @this.groundSystem.local_player_grounded_alive;
 
+        // In MP, replace local_player_grounded_alive flag with the following condition
         var planetId = @this.groundSystem.planet.id;
         var players = Multiplayer.Session.Combat.Players;
         for (var i = 0; i < players.Length; i++)

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
- Fix https://github.com/NebulaModTeam/nebula/issues/691 that cause by race condition of GetNgrokAddressAsync
This is caused by `NgrokManager.GetNgrokAddressAsync` is executed before `NgrokManager.StartNgrok` is fully completed. Thus test in `IsNgrokActive` causes InvalidOperationException.

- Fix half-growth dark fog bases keep regenerating
Note: `EnemyData.isInvincible` is used by Nebula client to note if the enemy is pending to get killed  
 `EnemyData.isInvincible` will get set back to true in EnemyDFGroundSystem.KeyTickLogic when base structure point > 0  
So we'll need to set `EnemyData.isInvincible` = true to let host's incoming KillEnemyFinally packet get executed  

- Fix combat drones doesn't increase ground base threat
Sync with `CombatStatDamagePacket` broadcast to host and players on the same planet

- Fix https://github.com/NebulaModTeam/nebula/issues/707: IndexOutOfRangeException in SpaceSector.RemoveEnemyWithComponents (IL_026A)
This is due to combatStats is not sync in client, so it needs to check if `EnemyData.combatStatId` is valid first.

