### PR TITLE
Sync extra texts in production statistics panel

### DIFF
--- a/NebulaModel/Packets/Statistics/StatisticsExtraDataPacket.cs
+++ b/NebulaModel/Packets/Statistics/StatisticsExtraDataPacket.cs
@@ -1,0 +1,15 @@
+﻿namespace NebulaModel.Packets.Statistics;
+
+public class StatisticsExtraDataPacket
+{
+    public StatisticsExtraDataPacket() { }
+
+    public StatisticsExtraDataPacket(int factoryCount, byte[] binaryData)
+    {
+        FactoryCount = factoryCount;
+        BinaryData = binaryData;
+    }
+
+    public int FactoryCount { get; set; }
+    public byte[] BinaryData { get; set; }
+}

--- a/NebulaModel/Packets/Statistics/StatisticsRequestEvent.cs
+++ b/NebulaModel/Packets/Statistics/StatisticsRequestEvent.cs
@@ -4,16 +4,19 @@ public class StatisticsRequestEvent
 {
     public StatisticsRequestEvent() { }
 
-    public StatisticsRequestEvent(StatisticEvent Event)
+    public StatisticsRequestEvent(StatisticEvent statisticEvent, int astroFilter)
     {
-        this.Event = Event;
+        Event = statisticEvent;
+        AstroFilter = astroFilter;
     }
 
     public StatisticEvent Event { get; set; }
+    public int AstroFilter { get; set; }
 }
 
 public enum StatisticEvent
 {
     WindowOpened = 1,
-    WindowClosed = 2
+    WindowClosed = 2,
+    AstroFilterChanged = 3
 }

--- a/NebulaNetwork/PacketProcessors/Statistics/StatisticsExtraDataProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Statistics/StatisticsExtraDataProcessor.cs
@@ -1,0 +1,61 @@
+﻿#region
+
+using System.IO;
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Statistics;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Statistics;
+
+[RegisterPacketProcessor]
+internal class StatisticsExtraDataProcessor : PacketProcessor<StatisticsExtraDataPacket>
+{
+    protected override void ProcessPacket(StatisticsExtraDataPacket packet, NebulaConnection conn)
+    {
+        using var reader = new BinaryUtils.Reader(packet.BinaryData);
+        ImportExtension(reader.BinaryReader, packet.FactoryCount);
+    }
+
+    static void ImportExtension(BinaryReader reader, int factoryCount)
+    {
+        var factoryStatPool = GameMain.data.statistics.production.factoryStatPool;
+        for (var i = 0; i < factoryCount; i++)
+        {
+            var factoryIndex = reader.ReadInt32();
+            if (factoryIndex >= factoryStatPool.Length) return; // Abort if factoryProductionStat hasn't imported yet
+            var factoryProductionStat = factoryStatPool[factoryIndex];
+            ImportProductStatExtension(reader, factoryProductionStat);
+        }
+    }
+
+    static void ImportProductStatExtension(BinaryReader reader, FactoryProductionStat factoryProductionStat)
+    {
+        var productCursor = reader.ReadInt32();
+        for (var i = 1; i < productCursor; i++)
+        {
+            var itemId = reader.ReadInt32();
+            var refProductSpeed = reader.ReadSingle();
+            var refConsumeSpeed = reader.ReadSingle();
+            var storageCount = reader.ReadInt64();
+            var trashCount = reader.ReadInt64();
+            var importStorageCount = reader.ReadInt64();
+            var exportStorageCount = reader.ReadInt64();
+
+            if (factoryProductionStat == null) continue;
+            var index = factoryProductionStat.productIndices[itemId];
+            if (index == 0) continue;
+
+            var product = factoryProductionStat.productPool[index];
+            product.refProductSpeed = refProductSpeed;
+            product.refConsumeSpeed = refConsumeSpeed;
+            product.storageCount = storageCount;
+            product.trashCount = trashCount;
+            product.importStorageCount = importStorageCount;
+            product.exportStorageCount = exportStorageCount;
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Statistics/StatisticsRequestEventProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Statistics/StatisticsRequestEventProcessor.cs
@@ -1,8 +1,6 @@
 ﻿#region
 
-using System;
 using System.IO;
-using NebulaAPI.GameState;
 using NebulaAPI.Packets;
 using NebulaModel.Networking;
 using NebulaModel.Packets;
@@ -28,22 +26,100 @@ internal class StatisticsRequestEventProcessor : PacketProcessor<StatisticsReque
         {
             return;
         }
+        NebulaModel.Logger.Log.Debug($"{packet.Event} {packet.AstroFilter} player={player.Id}");
         switch (packet.Event)
         {
             case StatisticEvent.WindowOpened:
                 {
                     Multiplayer.Session.Statistics.RegisterPlayer(conn, player.Id);
 
-                    using var writer = new BinaryUtils.Writer();
-                    Multiplayer.Session.Statistics.ExportAllData(writer.BinaryWriter);
-                    conn.SendPacket(new StatisticsDataPacket(writer.CloseAndGetBytes()));
+                    using (var writer = new BinaryUtils.Writer())
+                    {
+                        Multiplayer.Session.Statistics.ExportAllData(writer.BinaryWriter);
+                        conn.SendPacket(new StatisticsDataPacket(writer.CloseAndGetBytes()));
+                    }
+                    SendExtraData(conn, packet.AstroFilter);
                     break;
                 }
             case StatisticEvent.WindowClosed:
                 Multiplayer.Session.Statistics.UnRegisterPlayer(player.Id);
                 break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(packet), "Unknown event type: " + packet.Event);
+
+            case StatisticEvent.AstroFilterChanged:
+                SendExtraData(conn, packet.AstroFilter);
+                break;
+        }
+    }
+
+    static void SendExtraData(NebulaConnection conn, int astroFilter)
+    {
+        if (astroFilter == 0) return;
+        var window = UIRoot.instance.uiGame.statWindow;
+        var originalAstroFilter = window.astroFilter;
+        window.astroFilter = astroFilter;
+        window.RefreshItemsCyclicRefSpeed();
+        window.RefreshItemsStorageGroupCount();
+        window.RefreshGalacticTransportStorageCount();
+        window.astroFilter = originalAstroFilter;
+
+        using var writer = new BinaryUtils.Writer();
+        var factoryCount = ExportExtension(writer.BinaryWriter, astroFilter);
+        conn.SendPacket(new StatisticsExtraDataPacket(factoryCount, writer.CloseAndGetBytes()));
+    }
+
+    static int ExportExtension(BinaryWriter writer, int astroFilter)
+    {
+        var factoryStatPool = GameMain.data.statistics.production.factoryStatPool;
+        var factoryCount = 0;
+        if (astroFilter == -1)
+        {
+            for (var i = 0; i < GameMain.data.factoryCount; i++)
+            {
+                writer.Write(i);
+                ExportProductStatExtension(writer, factoryStatPool[i]);
+                factoryCount++;
+            }
+        }
+        else if (astroFilter % 100 == 0)
+        {
+            var star = GameMain.galaxy.StarById(astroFilter / 100);
+            if (star == null) return 0;
+            for (var i = 0; i < star.planetCount; i++)
+            {
+                var planet = star.planets[i];
+                if (planet?.factory != null)
+                {
+                    var factoryIndex = planet.factoryIndex;
+                    writer.Write(factoryIndex);
+                    ExportProductStatExtension(writer, factoryStatPool[factoryIndex]);
+                    factoryCount++;
+                }
+            }
+        }
+        else
+        {
+            var planet = GameMain.galaxy.PlanetById(astroFilter);
+            if (planet?.factory == null) return 0;
+            writer.Write(planet.factoryIndex);
+            ExportProductStatExtension(writer, factoryStatPool[planet.factoryIndex]);
+            factoryCount = 1;
+        }
+        return factoryCount;
+    }
+
+    static void ExportProductStatExtension(BinaryWriter writer, FactoryProductionStat factoryProductionStat)
+    {
+        writer.Write(factoryProductionStat.productCursor);
+        for (var i = 1; i < factoryProductionStat.productCursor; i++)
+        {
+            var product = factoryProductionStat.productPool[i];
+            writer.Write(product.itemId);
+            writer.Write(product.refProductSpeed);
+            writer.Write(product.refConsumeSpeed);
+            writer.Write(product.storageCount);
+            writer.Write(product.trashCount);
+            writer.Write(product.importStorageCount);
+            writer.Write(product.exportStorageCount);
         }
     }
 }

--- a/NebulaNetwork/Server.cs
+++ b/NebulaNetwork/Server.cs
@@ -43,7 +43,6 @@ public class Server : IServer
     public INetPacketProcessor PacketProcessor { get; set; } = new NebulaNetPacketProcessor();
 
     private const float GAME_RESEARCH_UPDATE_INTERVAL = 2;
-    private const float STATISTICS_UPDATE_INTERVAL = 1;
     private const float LAUNCH_UPDATE_INTERVAL = 4;
     private const float DYSONSPHERE_UPDATE_INTERVAL = 2;
     private const float WARNING_UPDATE_INTERVAL = 1;
@@ -54,8 +53,6 @@ public class Server : IServer
 
     private float gameResearchHashUpdateTimer;
     private NgrokManager ngrokManager;
-    private float productionStatisticsUpdateTimer;
-
 
     private WebSocketServer socket;
     private float warningUpdateTimer;
@@ -414,7 +411,6 @@ public class Server : IServer
         }
 
         gameResearchHashUpdateTimer += Time.deltaTime;
-        productionStatisticsUpdateTimer += Time.deltaTime;
         dysonLaunchUpateTimer += Time.deltaTime;
         dysonSphereUpdateTimer += Time.deltaTime;
         warningUpdateTimer += Time.deltaTime;
@@ -428,12 +424,6 @@ public class Server : IServer
                 SendPacket(new GameHistoryResearchUpdatePacket(GameMain.data.history.currentTech, state.hashUploaded,
                     state.hashNeeded, GameMain.statistics.techHashedFor10Frames, GameMain.data.history.techQueueLength));
             }
-        }
-
-        if (productionStatisticsUpdateTimer > STATISTICS_UPDATE_INTERVAL)
-        {
-            productionStatisticsUpdateTimer = 0;
-            Multiplayer.Session.Statistics.SendBroadcastIfNeeded();
         }
 
         if (dysonLaunchUpateTimer > LAUNCH_UPDATE_INTERVAL)

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -329,6 +329,7 @@ internal class GameData_Patch
         if (Multiplayer.Session.LocalPlayer.IsHost)
         {
             Multiplayer.Session.Launch.CollectProjectile();
+            Multiplayer.Session.Statistics.SendBroadcastIfNeeded(time);
             return;
         }
 

--- a/NebulaPatcher/Patches/Dynamic/UIProductEntry_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIProductEntry_Patch.cs
@@ -1,0 +1,37 @@
+﻿#region
+
+using HarmonyLib;
+using NebulaModel.Packets.Statistics;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Dynamic;
+
+[HarmonyPatch(typeof(UIProductEntry))]
+internal class UIProductEntry_Patch
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIProductEntry.OnRefreshRefSpeedClick))]
+    [HarmonyPatch(nameof(UIProductEntry.OnRefreshStorageCountClick))]
+    public static void OnRefreshClick_Postfix()
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return;
+        }
+
+        // When client left-click the refresh button, request the extra data from server
+        var astroFilter = UIRoot.instance.uiGame.statWindow.astroFilter;
+        if (astroFilter == 0)
+        {
+            if (GameMain.localPlanet != null) return;
+            astroFilter = GameMain.localStar?.id ?? 0;
+        }
+        else if (GameMain.localPlanet != null && GameMain.localPlanet.astroId == astroFilter)
+        {
+            return; // For local planet, use the local calculation
+        }
+        Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.AstroFilterChanged, astroFilter));
+    }
+}

--- a/NebulaPatcher/Patches/Dynamic/UIStatisticsWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStatisticsWindow_Patch.cs
@@ -12,7 +12,7 @@ namespace NebulaPatcher.Patches.Dynamic;
 [HarmonyPatch(typeof(UIStatisticsWindow))]
 internal class UIStatisticsWindow_Patch
 {
-    [HarmonyPostfix]
+    [HarmonyPrefix]
     [HarmonyPatch(nameof(UIStatisticsWindow._OnOpen))]
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
     public static void _OnOpen_Postfix()

--- a/NebulaPatcher/Patches/Dynamic/UIStatisticsWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIStatisticsWindow_Patch.cs
@@ -15,14 +15,19 @@ internal class UIStatisticsWindow_Patch
     [HarmonyPrefix]
     [HarmonyPatch(nameof(UIStatisticsWindow._OnOpen))]
     [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Original Function Name")]
-    public static void _OnOpen_Postfix()
+    public static void _OnOpen_Postfix(UIStatisticsWindow __instance)
     {
         if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
         {
             return;
         }
         Multiplayer.Session.Statistics.IsStatisticsNeeded = true;
-        Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.WindowOpened));
+        var astroFilter = __instance.astroFilter;
+        if (astroFilter == 0)
+        {
+            astroFilter = GameMain.localPlanet?.astroId ?? (GameMain.localStar?.id ?? 0);
+        }
+        Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.WindowOpened, astroFilter));
     }
 
     [HarmonyPostfix]
@@ -36,7 +41,7 @@ internal class UIStatisticsWindow_Patch
             return;
         }
         Multiplayer.Session.Statistics.IsStatisticsNeeded = false;
-        Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.WindowClosed));
+        Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.WindowClosed, 0));
     }
 
     [HarmonyPrefix]
@@ -46,5 +51,36 @@ internal class UIStatisticsWindow_Patch
     {
         //Skip when StatisticsDataPacket hasn't arrived yet
         return _factoryIndex >= 0 && ___productionStat.factoryStatPool[_factoryIndex] != null;
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(UIStatisticsWindow.AstroBoxToValue))]
+    public static void AstroBoxToValue_Postfix(UIStatisticsWindow __instance)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost) return;
+
+        if (__instance.isStatisticsTab && __instance.lastAstroFilter != __instance.astroFilter)
+        {
+            if (__instance.astroFilter != 0)
+            {
+                Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.AstroFilterChanged, __instance.astroFilter));
+            }
+            else if (GameMain.localPlanet == null && GameMain.localStar != null) // local star
+            {
+                Multiplayer.Session.Network.SendPacket(new StatisticsRequestEvent(StatisticEvent.AstroFilterChanged, GameMain.localStar.astroId));
+            }
+        }
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(nameof(UIStatisticsWindow.RefreshItemsCyclicRefSpeed))]
+    [HarmonyPatch(nameof(UIStatisticsWindow.RefreshItemsStorageGroupCount))]
+    [HarmonyPatch(nameof(UIStatisticsWindow.RefreshGalacticTransportStorageCount))]
+    public static bool Refresh_Prefix(UIStatisticsWindow __instance)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost) return true;
+
+        // Client: Only allow refresh on local planet. Otherwise use request to get data from server
+        return GameMain.localPlanet != null && (__instance.astroFilter == 0 || __instance.astroFilter == GameMain.data.localPlanet.id);
     }
 }

--- a/NebulaPatcher/Patches/Transpilers/UIProductEntry_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIProductEntry_Transpiler.cs
@@ -1,0 +1,126 @@
+﻿#region
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using HarmonyLib;
+using NebulaModel.Logger;
+using NebulaWorld;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Transpilers;
+
+[HarmonyPatch(typeof(UIProductEntry))]
+public static class UIProductEntry_Transpiler
+{
+    [HarmonyTranspiler]
+    [HarmonyPatch(nameof(UIProductEntry.UpdateExtraProductTexts))]
+    private static IEnumerable<CodeInstruction> UpdateExtraProductTexts_Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        //Change: this.gameData.factoryCount
+        //To:     GetFactoryCount()
+        //Change: planetData.factoryIndex
+        //To:     GetFactoryIndex(planetData)
+        //Change: planetData.factory != null
+        //To:     HasFactory(planetData)
+        var codeInstructions = instructions as CodeInstruction[] ?? instructions.ToArray();
+        try
+        {
+            instructions = ReplaceFactoryCount(codeInstructions);
+            instructions = new CodeMatcher(instructions)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PlanetData), nameof(PlanetData.factoryIndex)))
+                )
+                .Repeat(matcher => matcher
+                    .SetAndAdvance(OpCodes.Call,
+                        AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(GetFactoryIndex)))
+                )
+                .InstructionEnumeration();
+            /*
+            // planetData.factory != null => GetFactoryIndex(planetData) != -1
+            instructions = new CodeMatcher(instructions)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PlanetData), nameof(PlanetData.factory))),
+                    new CodeMatch(OpCodes.Brfalse)
+                )
+                .Repeat(matcher => matcher
+                    .SetAndAdvance(OpCodes.Call, AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(GetFactoryIndex)))
+                    .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_I4_M1))
+                    .SetOpcodeAndAdvance(OpCodes.Beq_S)
+                )
+                .InstructionEnumeration()
+            */
+
+            instructions = new CodeMatcher(instructions)
+                .MatchForward(false,
+                    new CodeMatch(OpCodes.Ldfld,
+                        AccessTools.Field(typeof(PlanetData), nameof(PlanetData.factory))),
+                    new CodeMatch(OpCodes.Brfalse)
+                )
+                .Repeat(matcher => matcher
+                    .SetAndAdvance(OpCodes.Call, AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(HasFactory)))
+                )
+                .InstructionEnumeration();
+
+            return instructions;
+        }
+        catch
+        {
+            Log.Error("Transpiler UIProductEntry.UpdateExtraProductTexts failed. Mod version not compatible with game version.");
+            return codeInstructions;
+        }
+    }
+
+    private static IEnumerable<CodeInstruction> ReplaceFactoryCount(IEnumerable<CodeInstruction> instructions)
+    {
+        return new CodeMatcher(instructions)
+            .MatchForward(false,
+                new CodeMatch(OpCodes.Ldarg_0),
+                new CodeMatch(OpCodes.Ldfld,
+                    AccessTools.Field(typeof(UIProductEntry), nameof(UIProductEntry.gameData))),
+                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(GameData), nameof(GameData.factoryCount)))
+            )
+            .Repeat(matcher => matcher
+                .SetAndAdvance(OpCodes.Call, AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(GetFactoryCount)))
+                .RemoveInstructions(2)
+            )
+            .InstructionEnumeration();
+    }
+
+    private static int GetFactoryCount()
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return GameMain.data.factoryCount;
+        }
+        return Multiplayer.Session.Statistics.FactoryCount;
+    }
+
+    private static PlanetData GetPlanetData(int factoryId)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return GameMain.data.factories[factoryId].planet;
+        }
+        return Multiplayer.Session.Statistics.GetPlanetData(factoryId);
+    }
+
+    private static int GetFactoryIndex(PlanetData planet)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return planet.factoryIndex;
+        }
+        return Multiplayer.Session.Statistics.GetFactoryIndex(planet);
+    }
+
+    private static bool HasFactory(PlanetData planet)
+    {
+        if (!Multiplayer.IsActive || Multiplayer.Session.LocalPlayer.IsHost)
+        {
+            return planet.factory != null;
+        }
+        return Multiplayer.Session.Statistics.HasFactory(planet);
+    }
+}

--- a/NebulaPatcher/Patches/Transpilers/UIProductEntry_Transpiler.cs
+++ b/NebulaPatcher/Patches/Transpilers/UIProductEntry_Transpiler.cs
@@ -37,20 +37,6 @@ public static class UIProductEntry_Transpiler
                         AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(GetFactoryIndex)))
                 )
                 .InstructionEnumeration();
-            /*
-            // planetData.factory != null => GetFactoryIndex(planetData) != -1
-            instructions = new CodeMatcher(instructions)
-                .MatchForward(false,
-                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(PlanetData), nameof(PlanetData.factory))),
-                    new CodeMatch(OpCodes.Brfalse)
-                )
-                .Repeat(matcher => matcher
-                    .SetAndAdvance(OpCodes.Call, AccessTools.Method(typeof(UIProductEntry_Transpiler), nameof(GetFactoryIndex)))
-                    .InsertAndAdvance(new CodeInstruction(OpCodes.Ldc_I4_M1))
-                    .SetOpcodeAndAdvance(OpCodes.Beq_S)
-                )
-                .InstructionEnumeration()
-            */
 
             instructions = new CodeMatcher(instructions)
                 .MatchForward(false,

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -102,13 +102,6 @@ public class SimulatedWorld : IDisposable
             player.Data.Mecha.UpdateMech(GameMain.mainPlayer);
 
             // Fix references that broke during import
-            GameMain.mainPlayer.mecha.forge.mecha = GameMain.mainPlayer.mecha;
-            GameMain.mainPlayer.mecha.forge.player = GameMain.mainPlayer;
-            GameMain.mainPlayer.mecha.forge.gameHistory = GameMain.data.history;
-            GameMain.mainPlayer.mecha.forge.gameHistory = GameMain.data.history;
-            GameMain.mainPlayer.mecha.groundCombatModule.AfterImport(GameMain.data); // do we need to do something about the spaceSector?
-            GameMain.mainPlayer.mecha.spaceCombatModule.AfterImport(GameMain.data); // do we need to do something about the spaceSector?
-
             FixPlayerAfterImport();
         }
 
@@ -198,12 +191,23 @@ public class SimulatedWorld : IDisposable
     {
         var player = GameMain.mainPlayer;
 
+        // Mimic MechaForge.Init(Mecha _mecha)
+        player.mecha.forge.mecha = GameMain.mainPlayer.mecha;
+        player.mecha.forge.player = GameMain.mainPlayer;
+        player.mecha.forge.gameHistory = GameMain.data.history;
+        player.mecha.forge.gameHistory = GameMain.data.history;
+        player.mecha.forge.bottleneckItems = new HashSet<int>();
+
         // Inventory Capacity level 7 will increase package columncount from 10 -> 12
         var packageRowCount = (player.package.size - 1) / player.GetPackageColumnCount() + 1;
         // Make sure all slots are available on UI
         player.package.SetSize(player.packageColCount * packageRowCount);
         player.deliveryPackage.rowCount = packageRowCount;
         player.deliveryPackage.NotifySizeChange();
+
+        // do we need to do something about the spaceSector?
+        player.mecha.groundCombatModule.AfterImport(GameMain.data);
+        player.mecha.spaceCombatModule.AfterImport(GameMain.data);
 
         // Set fleetId = 0, fleetAstroId = 0 and fighter.craftId = 0
         var moduleFleets = player.mecha.groundCombatModule.moduleFleets;

--- a/NebulaWorld/Statistics/StatisticsManager.cs
+++ b/NebulaWorld/Statistics/StatisticsManager.cs
@@ -21,6 +21,7 @@ public class StatisticsManager : IDisposable
     private PlanetData[] planetDataMap = new PlanetData[GameMain.data.factories.Length];
 
     private List<StatisticalSnapShot> statisticalSnapShots = [];
+    private long lastUpdateTime;
 
     public bool IsStatisticsNeeded { get; set; }
     public long[] PowerEnergyStoredData { get; set; }
@@ -92,12 +93,13 @@ public class StatisticsManager : IDisposable
         statisticalSnapShots.Add(snapshot);
     }
 
-    public void SendBroadcastIfNeeded()
+    public void SendBroadcastIfNeeded(long time)
     {
-        if (!IsStatisticsNeeded)
+        if (!IsStatisticsNeeded || time % 60 != 0 || lastUpdateTime == time)
         {
             return;
         }
+        lastUpdateTime = time;
         using (GetRequestors(out var requestors))
         {
             if (requestors.Count <= 0)


### PR DESCRIPTION
- Fix #717 about client can't craft
- Sync 'Reference rate', 'Import/Export storage', 'Storage amount' in production statistics panel
![image](https://github.com/user-attachments/assets/2843d25b-039f-4370-8a7b-d20d5b699262)

For local planet, client will use the local calculation.
For remote planets, client will send a request to server and use the response to update extra texts.
The request will be sent when opening the window, switching astroFilter or left-clicking on refresh buttons.
