### PR TITLE
Nebula 0.9.13 for DSP 0.10.32.25552 Update 

### DIFF
--- a/.github/scripts/thunderstore_bundle.js
+++ b/.github/scripts/thunderstore_bundle.js
@@ -117,13 +117,13 @@ function generateManifest() {
   const manifest = {
     name: pluginInfo.name,
     description:
-      "With this mod you will be able to play with your friends in the same game! Now supports combat mode in game version 0.10.30",
+      "With this mod you will be able to play with your friends in the same game! Now supports combat mode in game version 0.10.32",
     version_number: pluginInfo.version,
     dependencies: [
       BEPINEX_DEPENDENCY,
       `nebula-${apiPluginInfo.name}-${apiPluginInfo.version}`,
       "PhantomGamers-IlLine-1.0.0",
-      "starfi5h-BulletTime-1.5.1",
+      "starfi5h-BulletTime-1.5.3",
     ],
     website_url: "https://github.com/hubastard/nebula"
   };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+0.9.13:
+- Compatible with game version 0.10.32.25552
+- @starfi5h: Sync ejector auto orbit and blueprint paste foundation
+- @starfi5h: Force enable drone and shield brust for client
+- Note: The dashboard is not synced. Clients will lose their custom stats when they leave the star system
+
 0.9.12:
 - Compatible with game version 0.10.31.24697
 - @starfi5h: Client can now use metadata to unlock tech. Sandbox unlock by client is now synced

--- a/NebulaModel/Packets/Factory/Ejector/EjectorAutoOrbitUpdatePacket.cs
+++ b/NebulaModel/Packets/Factory/Ejector/EjectorAutoOrbitUpdatePacket.cs
@@ -1,0 +1,17 @@
+﻿namespace NebulaModel.Packets.Factory.Ejector;
+
+public class EjectorAutoOrbitUpdatePacket
+{
+    public EjectorAutoOrbitUpdatePacket() { }
+
+    public EjectorAutoOrbitUpdatePacket(int ejectorIndex, bool autoOrbit, int planetId)
+    {
+        EjectorIndex = ejectorIndex;
+        AutoOrbit = autoOrbit;
+        PlanetId = planetId;
+    }
+
+    public int EjectorIndex { get; set; }
+    public bool AutoOrbit { get; set; }
+    public int PlanetId { get; set; }
+}

--- a/NebulaModel/Packets/Factory/Foundation/FoundationBlueprintPastePacket.cs
+++ b/NebulaModel/Packets/Factory/Foundation/FoundationBlueprintPastePacket.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+
+namespace NebulaModel.Packets.Factory.Foundation;
+
+public class FoundationBlueprintPastePacket
+{
+    public FoundationBlueprintPastePacket() { }
+
+    public FoundationBlueprintPastePacket(int planetId, Dictionary<int, byte> reformGridIds,
+        Dictionary<int, int> levelChanges, int reformType, int reformColor)
+    {
+        PlanetId = planetId;
+        ReformGridIds = reformGridIds;
+        LevelChanges = levelChanges;
+        ReformType = reformType;
+        ReformColor = reformColor;
+    }
+
+    public int PlanetId { get; set; }
+    public Dictionary<int, byte> ReformGridIds { get; set; }
+    public Dictionary<int, int> LevelChanges { get; set; }
+    public int ReformType { get; set; }
+    public int ReformColor { get; set; }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalIconProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalIconProcessor.cs
@@ -17,12 +17,9 @@ internal class BeltSignalIconProcessor : PacketProcessor<BeltSignalIconPacket>
     {
         using (Multiplayer.Session.Factories.IsIncomingRequest.On())
         {
-            var cargoTraffic = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.cargoTraffic;
-            if (cargoTraffic == null)
-            {
-                return;
-            }
-            cargoTraffic.SetBeltSignalIcon(packet.EntityId, packet.SignalId);
+            var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
+            if (factory == null || packet.EntityId >= factory.entityCursor) return;
+            factory.cargoTraffic.SetBeltSignalIcon(packet.EntityId, packet.SignalId);
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalNumberProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Belt/BeltSignalNumberProcessor.cs
@@ -17,12 +17,9 @@ internal class BeltSignalNumberProcessor : PacketProcessor<BeltSignalNumberPacke
     {
         using (Multiplayer.Session.Factories.IsIncomingRequest.On())
         {
-            var cargoTraffic = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.cargoTraffic;
-            if (cargoTraffic == null)
-            {
-                return;
-            }
-            cargoTraffic.SetBeltSignalNumber(packet.EntityId, packet.Number);
+            var factory = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory;
+            if (factory == null || packet.EntityId >= factory.entityCursor) return;
+            factory.cargoTraffic.SetBeltSignalNumber(packet.EntityId, packet.Number);
         }
     }
 }

--- a/NebulaNetwork/PacketProcessors/Factory/Ejector/EjectorAutoOrbitUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Ejector/EjectorAutoOrbitUpdateProcessor.cs
@@ -1,0 +1,32 @@
+﻿#region
+
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Ejector;
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Factory.Ejector;
+
+[RegisterPacketProcessor]
+internal class EjectorAutoOrbitUpdateProcessor : PacketProcessor<EjectorAutoOrbitUpdatePacket>
+{
+    protected override void ProcessPacket(EjectorAutoOrbitUpdatePacket packet, NebulaConnection conn)
+    {
+        var ejectorPool = GameMain.galaxy.PlanetById(packet.PlanetId)?.factory?.factorySystem?.ejectorPool;
+        if (ejectorPool == null) return;
+
+        if (packet.EjectorIndex == -1) // Set whole planet ejector event
+        {
+            for (var i = 1; i < ejectorPool.Length; i++)
+            {
+                if (ejectorPool[i].id == i) ejectorPool[i].autoOrbit = packet.AutoOrbit;
+            }
+        }
+        else if (packet.EjectorIndex > 0 && packet.EjectorIndex < ejectorPool.Length)
+        {
+            ejectorPool[packet.EjectorIndex].autoOrbit = packet.AutoOrbit;
+        }
+    }
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBlueprintPasteProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBlueprintPasteProcessor.cs
@@ -1,0 +1,212 @@
+﻿#region
+
+using System.Collections.Generic;
+using NebulaAPI;
+using NebulaAPI.Packets;
+using NebulaModel.Networking;
+using NebulaModel.Packets;
+using NebulaModel.Packets.Factory.Foundation;
+using NebulaWorld;
+using UnityEngine;
+#pragma warning disable IDE0007 // Use implicit type
+
+#endregion
+
+namespace NebulaNetwork.PacketProcessors.Factory.Foundation;
+
+[RegisterPacketProcessor]
+internal class FoundationBlueprintPasteProcessor : PacketProcessor<FoundationBlueprintPastePacket>
+{
+    protected override void ProcessPacket(FoundationBlueprintPastePacket packet, NebulaConnection conn)
+    {
+        var planet = GameMain.galaxy.PlanetById(packet.PlanetId);
+        var factory = planet?.factory;
+        if (factory == null) return;
+
+        using (Multiplayer.Session.Planets.IsIncomingRequest.On())
+        {
+            Multiplayer.Session.Factories.TargetPlanet = packet.PlanetId;
+            Multiplayer.Session.Factories.AddPlanetTimer(packet.PlanetId);
+            var specifyPlanet = GameMain.gpuiManager.specifyPlanet;
+            GameMain.gpuiManager.specifyPlanet = planet;
+
+            // Split BuildTool_BlueprintPaste.DetermineReforms into following functions
+            SetReform(factory, packet.ReformGridIds, packet.ReformType, packet.ReformColor);
+            AlterHeightMap(planet, packet.LevelChanges);
+            RemoveVeges(factory, packet.LevelChanges);
+            UpdateGeothermalStrength(factory);
+            AlterVeinModels(factory);
+
+            GameMain.gpuiManager.specifyPlanet = specifyPlanet;
+            Multiplayer.Session.Factories.TargetPlanet = NebulaModAPI.PLANET_NONE;
+        }
+    }
+
+    static void SetReform(PlanetFactory factory, Dictionary<int, byte> reformGridIds, int brushType, int brushColor)
+    {
+        PlatformSystem platformSystem = factory.platformSystem;
+        platformSystem.EnsureReformData();
+
+        foreach (int key in reformGridIds.Keys)
+        {
+            int reformIndex = factory.platformSystem.GetReformIndex(key >> 16, key & 65535);
+            byte reformData = reformGridIds[key];
+            int num17 = reformData >> 5;
+            int num18 = (reformData & 3);
+            if (reformIndex >= 0)
+            {
+                int reformType = platformSystem.GetReformType(reformIndex);
+                int reformColor = platformSystem.GetReformColor(reformIndex);
+                if (reformType != ((num17 == 0) ? brushType : num17) || reformColor != ((num18 == 0) ? brushColor : num18))
+                {
+                    factory.platformSystem.SetReformType(reformIndex, brushType);
+                    factory.platformSystem.SetReformColor(reformIndex, brushColor);
+                }
+            }
+        }
+    }
+    static void AlterHeightMap(PlanetData planet, Dictionary<int, int> heightLevelChanges)
+    {
+        PlanetRawData planetRawData = planet.data;
+        bool isPlanetLevelized = planet.levelized;
+
+        // Calculate the maximum height threshold for terrain modifications
+        int heightThreshold = (int)(planet.realRadius * 100f + 20f) - 60;
+
+        ushort[] heightMap = planetRawData.heightData;
+
+        foreach (KeyValuePair<int, int> heightChange in heightLevelChanges)
+        {
+            if (heightChange.Value > 0)
+            {
+                if (isPlanetLevelized)
+                {
+                    if (heightMap[heightChange.Key] >= heightThreshold)
+                    {
+                        if (planetRawData.GetModLevel(heightChange.Key) < 3)
+                        {
+                            planetRawData.SetModPlane(heightChange.Key, 0);
+                        }
+                        planet.AddHeightMapModLevel(heightChange.Key, heightChange.Value);
+                    }
+                }
+                else
+                {
+                    planet.AddHeightMapModLevel(heightChange.Key, heightChange.Value);
+                }
+            }
+        }
+
+        bool meshesUpdated = planet.UpdateDirtyMeshes();
+        if (GameMain.isRunning && meshesUpdated && planet == GameMain.localPlanet)
+        {
+            planet.factory?.RenderLocalPlanetHeightmap();
+        }
+    }
+
+    static void RemoveVeges(PlanetFactory planetFactory, Dictionary<int, int> heightLevelChanges)
+    {
+        PlanetRawData planetRawData = planetFactory.planet.data;
+        VegeData[] vegePool = planetFactory.vegePool;
+        int vegeCursor = planetFactory.vegeCursor;
+
+        for (int vegetationIndex = 1; vegetationIndex < vegeCursor; vegetationIndex++)
+        {
+            if (vegePool[vegetationIndex].id != 0)
+            {
+                int terrainIndex = planetRawData.QueryIndex(vegePool[vegetationIndex].pos);
+                if (heightLevelChanges.TryGetValue(terrainIndex, out int modificationLevel) && modificationLevel >= 3)
+                {
+                    planetFactory.RemoveVegeWithComponents(vegetationIndex);
+                }
+            }
+        }
+    }
+
+    static void UpdateGeothermalStrength(PlanetFactory factory)
+    {
+        if (factory.planet.waterItemId != -1) return;
+
+        PowerSystem powerSystem = factory.powerSystem;
+        PowerGeneratorComponent[] generatorPool = powerSystem.genPool;
+        int generatorCount = powerSystem.genCursor;
+        EntityData[] entityPool = factory.entityPool;
+
+        for (int generatorIndex = 1; generatorIndex < generatorCount; generatorIndex++)
+        {
+            ref PowerGeneratorComponent generator = ref generatorPool[generatorIndex];
+            if (generator.id == generatorIndex && generator.geothermal && generator.entityId > 0)
+            {
+                generator.gthStrength = powerSystem.CalculateGeothermalStrenth(
+                    entityPool[generator.entityId].pos,
+                    entityPool[generator.entityId].rot,
+                    generator.baseRuinId
+                );
+            }
+        }
+    }
+
+    static void AlterVeinModels(PlanetFactory factory)
+    {
+        PlanetData planet = factory.planet;
+        PlanetRawData data = planet.data;
+
+        VeinData[] veinPool = factory.veinPool;
+        int veinCursor = factory.veinCursor;
+        float veinSurfaceThreshold = planet.realRadius - 50f + 5f;
+        PlanetPhysics physics = planet.physics;
+        for (int veinId = 1; veinId < veinCursor; veinId++)
+        {
+            ref VeinData veinPtr = ref veinPool[veinId];
+            if (veinPtr.id == veinId)
+            {
+                Vector3 pos = veinPtr.pos;
+                float magnitude = pos.magnitude;
+                if (magnitude >= veinSurfaceThreshold)
+                {
+                    float veinHeight = data.QueryModifiedHeight(pos) - 0.13f;
+                    int colliderId = veinPtr.colliderId;
+                    Vector3 vector = physics.GetColliderData(colliderId).pos.normalized * (veinHeight + 0.4f);
+                    int chunkId = colliderId >> 20;
+                    colliderId &= 1048575;
+                    physics.colChunks[chunkId].colliderPool[colliderId].pos = vector;
+                    Vector3 vectorNormal = pos / magnitude;
+                    veinPtr.pos = vectorNormal * veinHeight;
+                    physics.SetPlanetPhysicsColliderDirty();
+                    if (Mathf.Abs(magnitude - veinSurfaceThreshold) > 0.1f)
+                    {
+                        Quaternion quaternion = Maths.SphericalRotation(pos, Random.value * 360f);
+                        GameMain.gpuiManager.AlterModel(veinPtr.modelIndex, veinPtr.modelId, veinId, pos, quaternion, false);
+                    }
+                    else
+                    {
+                        GameMain.gpuiManager.AlterModel(veinPtr.modelIndex, veinPtr.modelId, veinId, pos, false);
+                    }
+                    VeinProto veinProto = LDB.veins.Select((int)veinPool[veinId].type);
+                    if (veinProto != null)
+                    {
+                        if (veinPool[veinId].minerId0 > 0)
+                        {
+                            GameMain.gpuiManager.AlterModel(veinProto.MinerBaseModelIndex, veinPtr.minerBaseModelId, veinPtr.minerId0, vectorNormal * (veinHeight + 0.1f), false);
+                            GameMain.gpuiManager.AlterModel(veinProto.MinerCircleModelIndex, veinPtr.minerCircleModelId0, veinPtr.minerId0, vectorNormal * (veinHeight + 0.4f), false);
+                        }
+                        if (veinPool[veinId].minerId1 > 0)
+                        {
+                            GameMain.gpuiManager.AlterModel(veinProto.MinerCircleModelIndex, veinPtr.minerCircleModelId1, veinPtr.minerId1, vectorNormal * (veinHeight + 0.6f), false);
+                        }
+                        if (veinPool[veinId].minerId2 > 0)
+                        {
+                            GameMain.gpuiManager.AlterModel(veinProto.MinerCircleModelIndex, veinPtr.minerCircleModelId2, veinPtr.minerId2, vectorNormal * (veinHeight + 0.8f), false);
+                        }
+                        if (veinPool[veinId].minerId3 > 0)
+                        {
+                            GameMain.gpuiManager.AlterModel(veinProto.MinerCircleModelIndex, veinPtr.minerCircleModelId3, veinPtr.minerId3, vectorNormal * (veinHeight + 1f), false);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
+}

--- a/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
+++ b/NebulaNetwork/PacketProcessors/Factory/Foundation/FoundationBuildUpdateProcessor.cs
@@ -45,18 +45,20 @@ internal class FoundationBuildUpdateProcessor : PacketProcessor<FoundationBuildU
             //Perform terrain operation
             var center = packet.ExtraCenter.ToVector3();
             var area = packet.CirclePointCount;
+            var costSandCount = 0; // dummy value, won't use
+            var getSandCount = 0; // dummy value, won't use
             if (!packet.IsCircle) //Normal reform
             {
                 var reformPointsCount = factory.planet.aux.ReformSnap(packet.GroundTestPos.ToVector3(), packet.ReformSize,
                     packet.ReformType, packet.ReformColor, reformPoints, packet.ReformIndices, factory.platformSystem,
                     out var reformCenterPoint);
-                factory.ComputeFlattenTerrainReform(reformPoints, reformCenterPoint, packet.Radius, reformPointsCount);
+                factory.ComputeFlattenTerrainReform(reformPoints, reformCenterPoint, packet.Radius, reformPointsCount, ref costSandCount, ref getSandCount);
                 center = reformCenterPoint;
                 area = packet.ReformSize * packet.ReformSize;
             }
             else //Remove pit
             {
-                factory.ComputeFlattenTerrainReform(reformPoints, center, packet.Radius, packet.CirclePointCount, 3f, 1f);
+                factory.ComputeFlattenTerrainReform(reformPoints, center, packet.Radius, packet.CirclePointCount, ref costSandCount, ref getSandCount, 3f, 1f);
             }
             using (Multiplayer.Session.Factories.IsIncomingRequest.On())
             {

--- a/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/CargoTraffic_Patch.cs
@@ -122,27 +122,4 @@ internal class CargoTraffic_Patch
                 incBeltId, GameMain.data.localPlanet.id));
         }
     }
-
-    [HarmonyPostfix]
-    [HarmonyPatch(nameof(CargoTraffic.SetBeltSignalIcon))]
-    public static void SetBeltSignalIcon_Postfix(int entityId, int signalId)
-    {
-        // Notify others about belt memo icon changes
-        if (Multiplayer.IsActive && !Multiplayer.Session.Factories.IsIncomingRequest.Value)
-        {
-            Multiplayer.Session.Network.SendPacketToLocalStar(new BeltSignalIconPacket(entityId, signalId,
-                GameMain.data.localPlanet.id));
-        }
-    }
-
-    [HarmonyPostfix]
-    [HarmonyPatch(nameof(CargoTraffic.SetBeltSignalNumber))]
-    public static void SetBeltSignalNumber_Postfix(int entityId, float number)
-    {
-        if (Multiplayer.IsActive && !Multiplayer.Session.Factories.IsIncomingRequest.Value)
-        {
-            Multiplayer.Session.Network.SendPacketToLocalStar(new BeltSignalNumberPacket(entityId, number,
-                GameMain.data.localPlanet.id));
-        }
-    }
 }

--- a/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/GameData_Patch.cs
@@ -16,6 +16,7 @@ using NebulaModel.Packets.Session;
 using NebulaPatcher.Patches.Transpilers;
 using NebulaWorld;
 using NebulaWorld.GameStates;
+using NebulaWorld.Planet;
 using NebulaWorld.Warning;
 using UnityEngine;
 
@@ -405,31 +406,11 @@ internal class GameData_Patch
         {
             return;
         }
-        Multiplayer.Session.Drones.ClearAllRemoteDrones();
-        using (Multiplayer.Session.Ships.PatchLockILS.On())
-        {
-            for (var i = 0; i < __instance.localStar.planetCount; i++)
-            {
-                if (__instance.localStar.planets?[i] == null)
-                {
-                    continue;
-                }
-                var planet = __instance.localStar.planets[i];
-                if (planet.factory == null)
-                {
-                    continue;
-                }
-                planet.factory.Free();
-                planet.factory = null;
-                __instance.galaxy.astrosFactory[planet.id] = null; //Assigned by UpdateRuntimePose
-                __instance.factoryCount--;
-            }
-            Multiplayer.Session.Combat.OnAstroFactoryUnload();
-        }
         if (!Multiplayer.Session.IsInLobby)
         {
             Multiplayer.Session.Network.SendPacket(new PlayerUpdateLocalStarId(Multiplayer.Session.LocalPlayer.Id, -1));
         }
+        PlanetManager.UnloadAllFactories();
     }
 
     [HarmonyPrefix]

--- a/NebulaPatcher/Patches/Dynamic/UIEjectorWindow_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIEjectorWindow_Patch.cs
@@ -42,6 +42,28 @@ internal class UIEjectorWindow_Patch
     }
 
     [HarmonyPostfix]
+    [HarmonyPatch(nameof(UIEjectorWindow.OnClickAutoOrbitSwitchButton))]
+    public static void OnClickAutoOrbitSwitchButton_Postfix(UIEjectorWindow __instance)
+    {
+        if (!Multiplayer.IsActive || __instance.ejectorId == 0 || __instance.factory == null) return;
+
+        var autoOrbit = __instance.factory.factorySystem.ejectorPool[__instance.ejectorId].autoOrbit;
+        Multiplayer.Session.Network.SendPacketToLocalStar(new EjectorAutoOrbitUpdatePacket(__instance.ejectorId, autoOrbit,
+            GameMain.localPlanet?.id ?? -1));
+    }
+
+    [HarmonyPostfix]
+    [HarmonyPatch(nameof(UIEjectorWindow.OnApplyPlanetButtonClick))]
+    public static void OnApplyPlanetButtonClick_Postfix(UIEjectorWindow __instance)
+    {
+        if (!Multiplayer.IsActive || __instance.ejectorId == 0 || __instance.factory == null) return;
+
+        var autoOrbit = __instance.factory.factorySystem.ejectorPool[__instance.ejectorId].autoOrbit;
+        Multiplayer.Session.Network.SendPacketToLocalStar(new EjectorAutoOrbitUpdatePacket(-1, autoOrbit,
+            GameMain.localPlanet?.id ?? -1)); // ejectorId = -1 as setting whole planet
+    }
+
+    [HarmonyPostfix]
     [HarmonyPatch(nameof(UIEjectorWindow.OnEjectorIdChange))]
     public static void OnEjectorIdChange_Postfix(UIEjectorWindow __instance)
     {

--- a/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIFatalErrorTip_Patch.cs
@@ -117,7 +117,7 @@ internal class UIFatalErrorTip_Patch
     {
         if (btnClose != null) return;
 
-        const string PATH = "UI Root/Overlay Canvas/In Game/Windows/Window Template/panel-bg/btn-box/close-btn";
+        const string PATH = "UI Root/Overlay Canvas/In Game/Common Tools/Color Palette Panel/panel-bg/btn-box/close-wnd-btn";
         btnClose = CreateButton(PATH, __instance.transform, new Vector3(-5, 0, 0), OnCloseClick);
     }
 

--- a/NebulaPatcher/Patches/Dynamic/UIMarkerDetail_Patch.cs
+++ b/NebulaPatcher/Patches/Dynamic/UIMarkerDetail_Patch.cs
@@ -1,0 +1,23 @@
+﻿#region
+
+using HarmonyLib;
+
+#endregion
+
+namespace NebulaPatcher.Patches.Dynamic;
+
+[HarmonyPatch(typeof(UIMarkerDetail))]
+internal class UIMarkerDetail_Patch
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(UIMarkerDetail), nameof(UIMarkerDetail.SetInspectPlanet))]
+    public static void SetInspectPlanet_Prefix(UIMarkerDetail __instance)
+    {
+        // When teleporting to another planet, the inspect planet factory can be null
+        // So set the inspectPlanet to null first in here
+        if (__instance.inspectPlanet != null && __instance.inspectPlanet.factory == null)
+        {
+            __instance.inspectPlanet = null;
+        }
+    }
+}

--- a/NebulaWorld/Chat/Commands/DevCommandHandler.cs
+++ b/NebulaWorld/Chat/Commands/DevCommandHandler.cs
@@ -3,6 +3,7 @@
 using NebulaWorld.MonoBehaviours.Local.Chat;
 using NebulaModel.DataStructures.Chat;
 using HarmonyLib;
+using NebulaWorld.Planet;
 
 #endregion
 
@@ -39,6 +40,25 @@ public class DevCommandHandler : IChatCommandHandler
                     return;
                 }
 
+            case "unload-factories":
+                {
+                    if (Multiplayer.Session.IsServer)
+                    {
+                        window.SendLocalChatMessage("this command is only available for client", ChatMessageType.CommandOutputMessage);
+                    }
+                    else if (GameMain.localPlanet != null)
+                    {
+                        window.SendLocalChatMessage("can only unload when in space", ChatMessageType.CommandOutputMessage);
+                    }
+                    else
+                    {
+                        var factoryCount = GameMain.data.factoryCount;
+                        PlanetManager.UnloadAllFactories();
+                        window.SendLocalChatMessage($"unload factory count: {factoryCount}", ChatMessageType.CommandOutputMessage);
+                    }
+                    return;
+                }
+
             default:
                 window.SendLocalChatMessage("Unknown command: " + parameters[0], ChatMessageType.CommandOutputMessage);
                 return;
@@ -52,6 +72,6 @@ public class DevCommandHandler : IChatCommandHandler
 
     public string[] GetUsage()
     {
-        return ["sandbox", "load-cfg", "self-destruct"];
+        return ["sandbox", "load-cfg", "self-destruct", "unload-factories"];
     }
 }

--- a/NebulaWorld/Planet/PlanetManager.cs
+++ b/NebulaWorld/Planet/PlanetManager.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using NebulaModel.DataStructures;
+using NebulaModel.Logger;
 
 #endregion
 
@@ -21,5 +22,27 @@ public class PlanetManager : IDisposable
         PendingFactories = null;
         PendingTerrainData = null;
         GC.SuppressFinalize(this);
+    }
+
+    public static void UnloadAllFactories()
+    {
+        Log.Info("UnloadAllFactories");
+        var gameData = GameMain.data;
+        Multiplayer.Session.Drones.ClearAllRemoteDrones();
+        using (Multiplayer.Session.Ships.PatchLockILS.On())
+        {
+            for (var i = gameData.factoryCount - 1; i >= 0; i--)
+            {
+                var planet = gameData.factories[i].planet;
+                planet.factory.Free();
+                planet.factory = null;
+                gameData.galaxy.astrosFactory[planet.id] = null;  //Assigned by UpdateRuntimePose
+            }
+            gameData.factoryCount = 0;
+            Multiplayer.Session.Combat.OnAstroFactoryUnload();
+        }
+        // Temporarily clear all CustomCharts on the unloaded factories to avoid errors
+        gameData.statistics.charts.Free();
+        gameData.statistics.charts.Init(gameData);
     }
 }

--- a/NebulaWorld/SimulatedWorld.cs
+++ b/NebulaWorld/SimulatedWorld.cs
@@ -198,6 +198,12 @@ public class SimulatedWorld : IDisposable
         player.mecha.forge.gameHistory = GameMain.data.history;
         player.mecha.forge.bottleneckItems = new HashSet<int>();
 
+        // Unlock the mecha functions as Mecha.Init()
+        player.mecha.energyShieldBurstUnlocked = true;
+        player.mecha.constructionModule.droneEnabled = true;
+        player.mecha.constructionModule.droneConstructEnabled = true;
+        player.mecha.constructionModule.droneRepairEnabled = true;
+
         // Inventory Capacity level 7 will increase package columncount from 10 -> 12
         var packageRowCount = (player.package.size - 1) / player.GetPackageColumnCount() + 1;
         // Make sure all slots are available on UI

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The chat window can opened/closed using `Alt + Backtick` (configurable in Settin
 
 Major refactors will happen while the project grows or game updates. Join the [Discord Server](https://discord.gg/UHeB2QvgDa) if you want to see to latest state of our development. Check [Wiki](https://github.com/NebulaModTeam/nebula/wiki/About-Nebula) for overview of features.  
 
-The multiplayer mod now supports Dark Fog combat mode in the latest game version (0.10.31.x).  
+The multiplayer mod now supports Dark Fog combat mode in the latest game version (0.10.32.x).  
 Most of the battle aspects are sync, only few features are still WIP.  
 
 <details>
@@ -73,6 +73,7 @@ Most of the battle aspects are sync, only few features are still WIP.
 - [x] Broadcast notification syncing (events with guide icon)
 - [x] Logistics Control Panel (I) syncing (entry list and detail panel)
 - [ ] Goal system (currently not available in client)
+- [ ] Custom dashboard (clients will lost their custom stats when they leave the star system)
 
 </details>
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.9.12",
+  "version": "0.9.13",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
- Force enable drone and shield brust for client
- Fix BeltSignalNumberPacket and BeltSignalIconPacket error
Change the hook position from CargoTraffic to UIBeltWindow so it doesn't get called on remote planets
- Sync ejector auto orbit settings
Use packet.EjectorIndex = -1 to represent the apply whole planet event
- Sync laying foundation in blueprint paste mode
Players can now press space to lay down foundations in blueprint mode
- Add new command `/dev unload-factories` for client to unload all factories

Note: The dashboard is not synced. Clients will lose their custom stats when they leave the star system